### PR TITLE
Add basic tests for menu and inventory persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+

--- a/index.js
+++ b/index.js
@@ -123,6 +123,28 @@ function restartBot() {
     }, 3000);
 }
 
+function mainMenuKeyboard() {
+  return {
+    inline_keyboard: [
+      [{ text: "🩸 Выйти на охоту", callback_data: "hunt" }],
+      [{ text: "🪦 Лутать тело 📦", callback_data: "loot_menu" }],
+      [{ text: "🎒 Инвентарь", callback_data: "inventory" }],
+      [{ text: "🏆 Таблица лидеров", callback_data: "leaderboard" }],
+      [{ text: "⚔️ PvP", callback_data: "pvp_request" }],
+      [{ text: "🏰 Кланы", callback_data: "clans_menu" }]
+    ]
+  };
+}
+
+function lootMenuKeyboard() {
+  return {
+    inline_keyboard: [
+      [{ text: "🆓 Бесплатный подарок", callback_data: "free_gift" }],
+      [{ text: "⬅️ Назад", callback_data: "play" }]
+    ]
+  };
+}
+
 function startBot() {
     if (typeof bot !== 'undefined' && bot) {
         bot.removeAllListeners();
@@ -1843,7 +1865,9 @@ async function main() {
   startBot();
 }
 
-main().catch(console.error);
+if (process.env.NODE_ENV !== 'test') {
+  main().catch(console.error);
+}
 
 
 
@@ -2281,16 +2305,20 @@ bot.onText(/\/acceptbattle/, (msg) => {
 });
 }
 
-startBot();
+if (process.env.NODE_ENV !== 'test') {
+  startBot();
+}
 
 
 // === Anti-idle пинг ===
 // Используем встроенный fetch в Node.js 18+
-setInterval(() => {
+if (process.env.NODE_ENV !== 'test') {
+  setInterval(() => {
     fetch(process.env.RENDER_EXTERNAL_URL || "https://crimecore-bot.onrender.com")
-        .then(() => console.log("Пинг OK"))
-        .catch(err => console.error("Пинг не удался:", err));
-}, 5 * 60 * 1000);
+      .then(() => console.log("Пинг OK"))
+      .catch(err => console.error("Пинг не удался:", err));
+  }, 5 * 60 * 1000);
+}
 
 
 // === Мини HTTP-сервер для Render ===
@@ -2307,13 +2335,19 @@ async function initPostgres() {
   )`);
 }
 
-const PORT = process.env.PORT || 3000;
-http.createServer((req, res) => {
+if (process.env.NODE_ENV !== 'test') {
+  const PORT = process.env.PORT || 3000;
+  http.createServer((req, res) => {
     res.writeHead(200, {"Content-Type": "text/plain"});
     res.end("Bot is running\n");
-}).listen(PORT, () => console.log(`HTTP server running on port ${PORT}`));
+  }).listen(PORT, () => console.log(`HTTP server running on port ${PORT}`));
+}
 
 
 // Аккуратное сохранение при завершении процесса
-process.on('SIGTERM', () => { saveData().finally(() => process.exit(0)); });
-process.on('SIGINT', () => { saveData().finally(() => process.exit(0)); });
+if (process.env.NODE_ENV !== 'test') {
+  process.on('SIGTERM', () => { saveData().finally(() => process.exit(0)); });
+  process.on('SIGINT', () => { saveData().finally(() => process.exit(0)); });
+}
+
+export { mainMenuKeyboard, lootMenuKeyboard };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,14 @@
         "grammy": "^1.27.0",
         "node-fetch": "^2.7.0",
         "node-telegram-bot-api": "^0.66.0",
+        "pg": "^8.11.5",
         "sharp": "^0.34.3"
       },
       "devDependencies": {
         "nodemon": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cypress/request": {
@@ -2307,6 +2311,95 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2327,6 +2420,45 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -2890,6 +3022,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -3380,6 +3521,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
   "dependencies": {
     "dotenv": "^17.2.1",

--- a/test/buttons.test.js
+++ b/test/buttons.test.js
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+process.env.NODE_ENV = 'test';
+const { mainMenuKeyboard, lootMenuKeyboard } = await import('../index.js');
+
+test('main menu contains all expected buttons', () => {
+  const keyboard = mainMenuKeyboard();
+  const callbacks = keyboard.inline_keyboard.flat().map(btn => btn.callback_data);
+  assert.ok(callbacks.includes('hunt'));
+  assert.ok(callbacks.includes('loot_menu'));
+  assert.ok(callbacks.includes('inventory'));
+  assert.ok(callbacks.includes('leaderboard'));
+  assert.ok(callbacks.includes('pvp_request'));
+  assert.ok(callbacks.includes('clans_menu'));
+});
+
+test('loot menu contains free gift and back buttons', () => {
+  const keyboard = lootMenuKeyboard();
+  const callbacks = keyboard.inline_keyboard.flat().map(btn => btn.callback_data);
+  assert.deepStrictEqual(callbacks, ['free_gift', 'play']);
+});

--- a/test/inventory.test.js
+++ b/test/inventory.test.js
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dataPath = path.join(__dirname, '..', 'data.json');
+
+test('inventory persists in data.json', async () => {
+  const original = await fs.readFile(dataPath, 'utf-8').catch(() => '{}');
+  try {
+    const data = JSON.parse(original || '{}');
+    data.players = data.players || {};
+    data.players.test = { id: 'test', inventory: { weapon: { name: 'Бита' } } };
+    await fs.writeFile(dataPath, JSON.stringify(data));
+    const loaded = JSON.parse(await fs.readFile(dataPath, 'utf-8'));
+    assert.equal(loaded.players.test.inventory.weapon.name, 'Бита');
+  } finally {
+    await fs.writeFile(dataPath, original);
+  }
+});


### PR DESCRIPTION
## Summary
- add top-level keyboard helpers and guard runtime code for testing
- configure npm test with Node's built-in runner
- add tests for menu buttons and inventory persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e5747298832aa5bfff32d1adfaa8