### PR TITLE
fix: define armor and helmet bonus handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,6 +273,16 @@ function cleanDatabase() {
   saveData();
 }
 
+function applyArmorHelmetBonuses(player) {
+  if (!player || !player.inventory) return;
+  const armorHp = player.inventory.armor && typeof player.inventory.armor.hp === 'number'
+    ? player.inventory.armor.hp
+    : 0;
+  player.maxHp = 100 + armorHp;
+  if (typeof player.hp !== 'number') player.hp = player.maxHp;
+  if (player.hp > player.maxHp) player.hp = player.maxHp;
+}
+
 // --- Config constants ---
 const PVP_REQUEST_TTL = 60 * 1000;
 const PVP_POINT = 300;


### PR DESCRIPTION
## Summary
- add missing armor/helmet bonus helper to update player max HP from equipped armor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6eed6e814832ab8fe8f80905f6f2a