### PR TITLE
Initialize save flags before database cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,10 @@ let clans = data.clans;
 let clanInvites = data.clanInvites || {};
 let clanBattles = data.clanBattles;
 
+// Prevent concurrent writes under heavy load
+let saving = false;
+let saveAgain = false;
+
   await initPostgres();
   await loadData();
   cleanDatabase();
@@ -534,10 +538,6 @@ async function giveItemToPlayer(chatId, player, item, sourceText = "") {
 }
 
 // ---- Data load/save and migration ----
-
-// Prevent concurrent writes under heavy load
-let saving = false;
-let saveAgain = false;
 
 async function saveData() {
   if (saving) {


### PR DESCRIPTION
## Summary
- Prevent `ReferenceError` during startup by defining `saving` and `saveAgain` before any call to `cleanDatabase`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70543ccec832aa1456bbe03614df4