### PR TITLE
Fix persistent data storage

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,15 +1,35 @@
-import mysql from 'mysql2/promise';
 import dotenv from 'dotenv';
 dotenv.config();
 
-const pool = mysql.createPool({
-  host: process.env.DB_HOST,
-  user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME,
-  waitForConnections: true,
-  connectionLimit: 10,
-  queueLimit: 0
-});
+let pool;
+
+if (process.env.NODE_ENV === 'test') {
+  pool = {
+    async execute() {
+      throw new Error('Test pool.execute stub not configured');
+    }
+  };
+} else {
+  try {
+    const mysqlModule = await import('mysql2/promise');
+    const mysql = mysqlModule.default || mysqlModule;
+    pool = mysql.createPool({
+      host: process.env.DB_HOST,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
+      waitForConnections: true,
+      connectionLimit: 10,
+      queueLimit: 0
+    });
+  } catch (err) {
+    console.error('Не удалось инициализировать пул MySQL:', err);
+    pool = {
+      async execute() {
+        throw err;
+      }
+    };
+  }
+}
 
 export default pool;

--- a/test/persistence.test.js
+++ b/test/persistence.test.js
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+process.env.NODE_ENV = 'test';
+
+const pool = (await import('../lib/db.js')).default;
+
+let storedState = null;
+
+pool.execute = async (query, params = []) => {
+  if (query.includes('SELECT state FROM bot_state')) {
+    if (!storedState) {
+      return [[], []];
+    }
+    return [[{ state: storedState }], []];
+  }
+  if (query.includes('INSERT INTO bot_state')) {
+    storedState = params[0];
+    return [{ affectedRows: 1 }, undefined];
+  }
+  throw new Error(`Unexpected query in test stub: ${query}`);
+};
+
+const {
+  saveData,
+  loadData,
+  __setStateForTests,
+  __getStateForTests
+} = await import('../index.js');
+
+test('player state persists across save and load cycle', async () => {
+  storedState = null;
+
+  await loadData();
+
+  __setStateForTests({
+    players: {
+      '42': {
+        id: 42,
+        username: 'tester',
+        infection: 1234,
+        inventory: {
+          weapon: { name: 'Бита', dmg: 10 },
+          armor: null,
+          helmet: null,
+          mutation: null,
+          extra: null
+        }
+      }
+    },
+    clans: {},
+    clanBattles: [],
+    clanInvites: {}
+  });
+
+  await saveData();
+
+  __setStateForTests({ players: {}, clans: {}, clanBattles: [], clanInvites: {} });
+
+  await loadData();
+
+  const state = __getStateForTests();
+  assert.ok(state.players['42'], 'player should exist after load');
+  assert.strictEqual(state.players['42'].infection, 1234);
+  assert.strictEqual(state.players['42'].inventory.weapon.name, 'Бита');
+});


### PR DESCRIPTION
## Summary
- consolidate game state in module scope, ensure saveData/loadData persist to MySQL and fall back to local data when needed
- expose minimal test helpers and add a persistence regression test to confirm earned progress survives reloads
- make the DB client test-friendly by stubbing mysql2 when running under NODE_ENV=test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d140b5c5f4832aa0d0f88d199e8f08