### PR TITLE
Добавить выбор режима PvP

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,15 +1,28 @@
-import mysql from 'mysql2/promise';
 import dotenv from 'dotenv';
 dotenv.config();
 
-const pool = mysql.createPool({
-  host: process.env.DB_HOST,
-  user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME,
-  waitForConnections: true,
-  connectionLimit: 10,
-  queueLimit: 0
-});
+let pool = {
+  execute: async () => [],
+  query: async () => [],
+  getConnection: async () => ({ release: () => {} })
+};
+
+if (process.env.NODE_ENV !== 'test') {
+  try {
+    const mysqlModule = await import('mysql2/promise');
+    const mysql = mysqlModule.default || mysqlModule;
+    pool = mysql.createPool({
+      host: process.env.DB_HOST,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
+      waitForConnections: true,
+      connectionLimit: 10,
+      queueLimit: 0
+    });
+  } catch (err) {
+    console.error('Ошибка инициализации MySQL:', err);
+  }
+}
 
 export default pool;

--- a/test/buttons.test.js
+++ b/test/buttons.test.js
@@ -11,12 +11,12 @@ test('main menu contains all expected buttons', () => {
   assert.ok(callbacks.includes('loot_menu'));
   assert.ok(callbacks.includes('inventory'));
   assert.ok(callbacks.includes('leaderboard'));
-  assert.ok(callbacks.includes('pvp_request'));
+  assert.ok(callbacks.includes('pvp_menu'));
   assert.ok(callbacks.includes('clans_menu'));
 });
 
 test('loot menu contains free gift and back buttons', () => {
   const keyboard = lootMenuKeyboard();
   const callbacks = keyboard.inline_keyboard.flat().map(btn => btn.callback_data);
-  assert.deepStrictEqual(callbacks, ['free_gift', 'play']);
+  assert.deepStrictEqual(callbacks, ['free_gift', 'invite_friend', 'play']);
 });


### PR DESCRIPTION
## Summary
- добавить меню выбора режима при нажатии на кнопку PvP
- отправлять изображение инвентаря игрока вместе с заявкой на PvP в чате
- реализовать автоматический поиск случайного соперника-бота и обновить заглушку БД для тестового режима

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14337ca18832a86770a347a6b26a4