### PR TITLE
Reduce hunt cooldown to 15 seconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -1520,7 +1520,7 @@ if (dataCb === "legend_box") {
 
 if (dataCb === "hunt") {
   const now = Date.now();
-  let huntCooldown = 40000;
+  let huntCooldown = 15000;
   if (player && (player.id === 7897895019 || player.id === 7026777373)) {
     huntCooldown = 1000;
   }


### PR DESCRIPTION
## Summary
- lower the default hunt action cooldown to 15 seconds so players can start hunts sooner

## Testing
- npm test *(fails: missing optional dependency mysql2 required by db module)*

------
https://chatgpt.com/codex/tasks/task_e_68d14edf3eb4832aa44c8beb100eb4a6