### PR TITLE
Add sign equipment and rare boss rewards

### DIFF
--- a/броня.txt
+++ b/броня.txt
@@ -55,3 +55,11 @@ awp: https://i.postimg.cc/hPff6mP2/awp.png
 Граната: https://i.postimg.cc/CLqfdDTz/3333.png
 Адреналин: https://i.postimg.cc/nhf9mzpT/image.png
 Газовый балон: https://i.postimg.cc/vmQ1PN1V/image.png
+Знак внимание: https://i.postimg.cc/FsPgB1v5/image.png
+Знак череп: https://i.postimg.cc/nhbcZGpv/image.png
+Знак 18+: https://i.postimg.cc/JzLDKLDV/18.png
+Знак CRIMECORE: https://i.postimg.cc/Gtv3s4jB/CRIMECORE.png
+Знак BIOHAZARD: https://i.postimg.cc/4x2GyvTL/BIOHAZARD.png
+Знак радиации: https://i.postimg.cc/4dzj6VrT/image.png
+Знак пустой: https://i.postimg.cc/C1H6BYqh/image.png
+Знак final CRIMECORE: https://i.postimg.cc/LsjxwRvt/final-CRIMECORE.png


### PR DESCRIPTION
## Summary
- add a dedicated sign slot with helper logic, purchaseable "Знаки 5000☣️" case, and inventory display updates
- implement a 5% hunt boss that drops the unique final CRIMECORE sign and extend combat with vampirism, dodge, and death-save sign effects
- register sign artwork so inventory renders the new items correctly

## Testing
- npm test *(fails: missing mysql2 dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d159034008832aae96389465ac3204