### PR TITLE
Add robust storage adapters and validate item images

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,19 @@ import sharp from 'sharp';
 import fetch from 'node-fetch';
 import http from 'http';
 
+import {
+  armorItems,
+  weaponItems,
+  helmetItems,
+  mutationItems,
+  extraItems,
+  signItems,
+  getItemImageMap,
+  normalizeItemName
+} from './lib/items.js';
 
 import pool from './lib/db.js';
+const DB_DIALECT = pool && pool.dialect ? pool.dialect : 'memory';
 
 // --- Очистка таблицы bot_state (MySQL) ---
 export async function clearBotStateTable() {
@@ -22,34 +33,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const TOKEN = process.env.TELEGRAM_TOKEN || process.env.TOKEN || process.env.BOT_TOKEN;
 
-
-
-function normalizeName(str) {
-  return String(str || '')
-    .toLowerCase()
-    .replace(/ё/g, 'е')
-    .replace(/[^a-zа-я0-9]/gi, '');
-}
-
-function loadItemImages() {
-  const filePath = path.join(__dirname, 'броня.txt');
-  const map = {};
-  if (fs.existsSync(filePath)) {
-    const lines = fs.readFileSync(filePath, 'utf-8').split(/\r?\n/);
-    for (const line of lines) {
-      const [name, url] = line.split(/\s*: \s*/);
-      if (name && url) {
-        map[normalizeName(name)] = url.trim();
-      }
-    }
-  }
-  return map;
-}
+const ITEM_IMAGE_MAP = getItemImageMap();
 
 async function generateInventoryImage(player) {
   try {
     const baseUrl = (player && player.baseUrl) || 'https://i.postimg.cc/RZbFRZzj/2.png';
-    const itemImages = loadItemImages();
     const layers = [];
 
     const resBase = await fetch(baseUrl);
@@ -60,7 +48,7 @@ async function generateInventoryImage(player) {
     for (const key of order) {
       const item = player && player.inventory ? player.inventory[key] : null;
       if (!item || !item.name) continue;
-      const url = itemImages[normalizeName(item.name)];
+      const url = ITEM_IMAGE_MAP[normalizeItemName(item.name)];
       if (!url) {
         console.warn(`Нет картинки для ${item ? item.name : key}`);
         continue;
@@ -154,12 +142,21 @@ async function readStateFromFile() {
 async function writeStateToDatabase(state) {
   if (!pool || typeof pool.execute !== 'function') return;
   const payload = JSON.stringify(state);
-  await pool.execute(
-    `INSERT INTO bot_state (id, state, updated_at)
-       VALUES (1, ?, NOW())
-       ON DUPLICATE KEY UPDATE state = VALUES(state), updated_at = NOW()`,
-    [payload]
-  );
+  if (DB_DIALECT === 'postgres') {
+    await pool.query(
+      `INSERT INTO bot_state (id, state, updated_at)
+         VALUES ($1, $2, NOW())
+         ON CONFLICT (id) DO UPDATE SET state = EXCLUDED.state, updated_at = NOW()`,
+      [1, payload]
+    );
+  } else {
+    await pool.execute(
+      `INSERT INTO bot_state (id, state, updated_at)
+         VALUES (1, ?, NOW())
+         ON DUPLICATE KEY UPDATE state = VALUES(state), updated_at = NOW()`,
+      [payload]
+    );
+  }
 }
 
 async function saveData() {
@@ -581,102 +578,6 @@ const CLAN_BATTLE_MIN_PER_CLAN = 2;
 const CLAN_BATTLE_COUNTDOWN_MS = 20000; // 20 seconds
 
 // --- Items (same as before) ---
-const armorItems = [
-  { name: "Бронежилет химзащита", hp: 20, chance: 25 },
-  { name: "Броня бинты", hp: 30, chance: 22 },
-  { name: "Бронежилет из жертв", hp: 40, chance: 20 },
-  { name: "Бронежилет любительский", hp: 50, chance: 18 },
-  { name: "Бронежилет базовый", hp: 100, chance: 15 },
-  { name: "Бронежилет полиции", hp: 250, chance: 10 },
-  { name: "Бронежилет военных", hp: 350, chance: 6 },
-  { name: "Бронежилет CRIMECORE", hp: 500, chance: 4 },
-  { name: "Бронежилет мутации", hp: 550, chance: 2 },
-  { name: "Бронежилет хим. вещества", hp: 600, chance: 1.5 },
-  { name: "Бронежилет протез", hp: 800, chance: 1 },
-  { name: "Броня хай-тек", hp: 1100, chance: 0.5 },
-  { name: "Броня скелет", hp: 1400, chance: 0.3 }
-];
-
-const weaponItems = [
-  { name: "Бита", dmg: 10, chance: 15 },
-  { name: "Перочинный нож", dmg: 15, chance: 13 },
-  { name: "Кухонный нож", dmg: 15, chance: 13 },
-  { name: "Охотничий нож", dmg: 20, chance: 12 },
-  { name: "Топор", dmg: 30, chance: 10 },
-  { name: "Мачете", dmg: 30, chance: 10 },
-  { name: "Бензопила", dmg: 40, chance: 6 },
-  { name: "Катана", dmg: 45, chance: 5 },
-  { name: "Glock-17", dmg: 70, chance: 5 },
-  { name: "Tec-9", dmg: 75, chance: 4 },
-  { name: "MP-7", dmg: 100, chance: 3 },
-  { name: "Uzi", dmg: 100, chance: 3 },
-  { name: "UMP", dmg: 120, chance: 2.5 },
-  { name: "Охотничье ружьё", dmg: 170, chance: 2 },
-  { name: "Дробовик", dmg: 180, chance: 1.5 },
-  { name: "Двустволка", dmg: 190, chance: 1.2 },
-  { name: "Famas", dmg: 210, chance: 1 },
-  { name: "M4", dmg: 240, chance: 0.7 },
-  { name: "Ak-47", dmg: 250, chance: 0.8 },
-  { name: "SCAR-L", dmg: 260, chance: 0.7 },
-  { name: "ВСК-94", dmg: 300, chance: 0.5 },
-  { name: "VSS", dmg: 370, chance: 0.25 },
-  { name: "AWP", dmg: 350, chance: 0.3 },
-  { name: "Гранатомет", dmg: 380, chance: 0.2 },
-  { name: "Подопытный", dmg: 450, chance: 0.1 }
-];
-
-const helmetItems = [
-  { name: "Пакет", block: 2, chance: 20 },
-  { name: "Шлем шапка", block: 3, chance: 19 },
-  { name: "Шлем бинты", block: 3, chance: 19 },
-  { name: "Кепка", block: 3, chance: 18 },
-  { name: "Балаклава", block: 3, chance: 18 },
-  { name: "Кожаный шлем", block: 5, chance: 15 },
-  { name: "Шлем Респиратор", block: 5, chance: 14 },
-  { name: "Велосипедный шлем", block: 5, chance: 15 },
-  { name: "Строительный шлем", block: 10, chance: 10 },
-  { name: "Противогаз", block: 20, chance: 6 },
-  { name: "Шлем пила", block: 20, chance: 4 },
-  { name: "Боевой шлем", block: 20, chance: 5 },
-  { name: "Военный шлем", block: 30, chance: 3 },
-  { name: "Шлем ночного видения", block: 25, chance: 2 },
-  { name: "Шлем стальной", block: 35, chance: 1.5 },
-  { name: "Шлем CRIMECORE", block: 40, chance: 2 }
-];
-
-const mutationItems = [
-  { name: "Зубной", crit: 0.10, chance: 25 },
-  { name: "Кровоточащий", crit: 0.15, chance: 20 },
-  { name: "Порезанный", crit: 0.15, chance: 20 },
-  { name: "Молчаливый", crit: 0.20, chance: 18 },
-  { name: "Аниме", crit: 0.20, chance: 15 },
-  { name: "Момо", crit: 0.20, chance: 15 },
-  { name: "Безликий", crit: 0.25, chance: 12 },
-  { name: "Зубастик", crit: 0.30, chance: 10 },
-  { name: "Клешни", crit: 0.30, chance: 6 },
-  { name: "Бог", crit: 0.50, chance: 2 }
-];
-
-const extraItems = [
-  { name: "Фотоаппарат со вспышкой", effect: "stun2", chance: 20, turns: 2 },
-  { name: "Слеповая граната", effect: "stun2", chance: 20, turns: 2 },
-  { name: "Петарда", effect: "damage50", chance: 20 },
-  { name: "Граната", effect: "damage100", chance: 15 },
-  { name: "Адреналин", effect: "halfDamage1", chance: 12, turns: 1 },
-  { name: "Газовый балон", effect: "doubleDamage1", chance: 6, turns: 1 },
-  ];
-
-const signItems = [
-  { name: "Знак внимание", kind: "sign", vampirism: 0.10, caseEligible: true },
-  { name: "Знак череп", kind: "sign", vampirism: 0.15, caseEligible: true },
-  { name: "Знак 18+", kind: "sign", vampirism: 0.20, caseEligible: true },
-  { name: "Знак CRIMECORE", kind: "sign", vampirism: 0.25, caseEligible: true },
-  { name: "Знак BIOHAZARD", kind: "sign", vampirism: 0.30, caseEligible: true },
-  { name: "Знак радиации", kind: "sign", preventLethal: "radiation", extraTurn: true, caseEligible: true },
-  { name: "Знак пустой", kind: "sign", dodgeChance: 0.20, caseEligible: true },
-  { name: "Знак final CRIMECORE", kind: "sign", preventLethal: "final", fullHeal: true, caseEligible: false }
-];
-
 function getSignTemplateByName(name) {
   if (!name) return null;
   const lower = String(name).toLowerCase();

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,27 +1,92 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-let pool = {
-  execute: async () => [],
-  query: async () => [],
-  getConnection: async () => ({ release: () => {} })
+const noopPool = {
+  dialect: 'memory',
+  async execute() {
+    return [[], { rows: [] }];
+  },
+  async query() {
+    return { rows: [] };
+  },
+  async getConnection() {
+    return { release() {} };
+  }
 };
 
+let pool = noopPool;
+
 if (process.env.NODE_ENV !== 'test') {
-  try {
-    const mysqlModule = await import('mysql2/promise');
-    const mysql = mysqlModule.default || mysqlModule;
-    pool = mysql.createPool({
-      host: process.env.DB_HOST,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB_NAME,
-      waitForConnections: true,
-      connectionLimit: 10,
-      queueLimit: 0
-    });
-  } catch (err) {
-    console.error('Ошибка инициализации MySQL:', err);
+  if (process.env.DATABASE_URL) {
+    try {
+      const pgModule = await import('pg');
+      const { Pool } = pgModule;
+      const pgPool = new Pool({
+        connectionString: process.env.DATABASE_URL,
+        ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : undefined
+      });
+      pool = {
+        dialect: 'postgres',
+        async execute(sql, params = []) {
+          const result = await pgPool.query(sql, params);
+          return [result.rows, result];
+        },
+        async query(sql, params = []) {
+          return pgPool.query(sql, params);
+        },
+        async getConnection() {
+          const client = await pgPool.connect();
+          return {
+            async execute(sql, params = []) {
+              const result = await client.query(sql, params);
+              return [result.rows, result];
+            },
+            async query(sql, params = []) {
+              return client.query(sql, params);
+            },
+            release() {
+              client.release();
+            }
+          };
+        },
+        async end() {
+          await pgPool.end();
+        }
+      };
+    } catch (err) {
+      console.error('Ошибка инициализации PostgreSQL:', err);
+    }
+  } else {
+    try {
+      const mysqlModule = await import('mysql2/promise');
+      const mysql = mysqlModule.default || mysqlModule;
+      const mysqlPool = mysql.createPool({
+        host: process.env.DB_HOST,
+        user: process.env.DB_USER,
+        password: process.env.DB_PASSWORD,
+        database: process.env.DB_NAME,
+        waitForConnections: true,
+        connectionLimit: 10,
+        queueLimit: 0
+      });
+      pool = {
+        dialect: 'mysql',
+        execute(sql, params = []) {
+          return mysqlPool.execute(sql, params);
+        },
+        query(sql, params = []) {
+          return mysqlPool.query(sql, params);
+        },
+        getConnection() {
+          return mysqlPool.getConnection();
+        },
+        end() {
+          return mysqlPool.end();
+        }
+      };
+    } catch (err) {
+      console.error('Ошибка инициализации MySQL:', err);
+    }
   }
 }
 

--- a/lib/items.js
+++ b/lib/items.js
@@ -1,0 +1,150 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+const IMAGE_FILE = path.join(ROOT_DIR, 'броня.txt');
+
+export const normalizeItemName = (str) =>
+  String(str || '')
+    .toLowerCase()
+    .replace(/ё/g, 'е')
+    .replace(/[^a-zа-я0-9]/gi, '');
+
+export const loadItemImageMap = () => {
+  const map = {};
+  if (!fs.existsSync(IMAGE_FILE)) {
+    return map;
+  }
+  const content = fs.readFileSync(IMAGE_FILE, 'utf-8');
+  const lines = content.split(/\r?\n/);
+  for (const raw of lines) {
+    if (!raw.trim()) continue;
+    const [name, url] = raw.split(/\s*:\s*/);
+    if (!name || !url) continue;
+    map[normalizeItemName(name)] = url.trim();
+  }
+  return map;
+};
+
+const ITEM_IMAGE_MAP = loadItemImageMap();
+
+export const getItemImageMap = () => ({ ...ITEM_IMAGE_MAP });
+
+export const armorItems = [
+  { name: "Бронежилет химзащита", hp: 20, chance: 25 },
+  { name: "Броня бинты", hp: 30, chance: 22 },
+  { name: "Бронежилет из жертв", hp: 40, chance: 20 },
+  { name: "Бронежилет любительский", hp: 50, chance: 18 },
+  { name: "Бронежилет базовый", hp: 100, chance: 15 },
+  { name: "Бронежилет полиции", hp: 250, chance: 10 },
+  { name: "Бронежилет военных", hp: 350, chance: 6 },
+  { name: "Бронежилет CRIMECORE", hp: 500, chance: 4 },
+  { name: "Бронежилет мутации", hp: 550, chance: 2 },
+  { name: "Бронежилет хим. вещества", hp: 600, chance: 1.5 },
+  { name: "Бронежилет протез", hp: 800, chance: 1 },
+  { name: "Броня хай-тек", hp: 1100, chance: 0.5 },
+  { name: "Броня скелет", hp: 1400, chance: 0.3 }
+];
+
+export const weaponItems = [
+  { name: "Бита", dmg: 10, chance: 15 },
+  { name: "Перочинный нож", dmg: 15, chance: 13 },
+  { name: "Кухонный нож", dmg: 15, chance: 13 },
+  { name: "Охотничий нож", dmg: 20, chance: 12 },
+  { name: "Топор", dmg: 30, chance: 10 },
+  { name: "Мачете", dmg: 30, chance: 10 },
+  { name: "Бензопила", dmg: 40, chance: 6 },
+  { name: "Катана", dmg: 45, chance: 5 },
+  { name: "Glock-17", dmg: 70, chance: 5 },
+  { name: "Tec-9", dmg: 75, chance: 4 },
+  { name: "MP-7", dmg: 100, chance: 3 },
+  { name: "Uzi", dmg: 100, chance: 3 },
+  { name: "UMP", dmg: 120, chance: 2.5 },
+  { name: "Охотничье ружьё", dmg: 170, chance: 2 },
+  { name: "Дробовик", dmg: 180, chance: 1.5 },
+  { name: "Двустволка", dmg: 190, chance: 1.2 },
+  { name: "Famas", dmg: 210, chance: 1 },
+  { name: "M4", dmg: 240, chance: 0.7 },
+  { name: "Ak-47", dmg: 250, chance: 0.8 },
+  { name: "SCAR-L", dmg: 260, chance: 0.7 },
+  { name: "ВСК-94", dmg: 300, chance: 0.5 },
+  { name: "VSS", dmg: 370, chance: 0.25 },
+  { name: "AWP", dmg: 350, chance: 0.3 },
+  { name: "Гранатомет", dmg: 380, chance: 0.2 },
+  { name: "Подопытный", dmg: 450, chance: 0.1 }
+];
+
+export const helmetItems = [
+  { name: "Пакет", block: 2, chance: 20 },
+  { name: "Шлем шапка", block: 3, chance: 19 },
+  { name: "Шлем бинты", block: 3, chance: 19 },
+  { name: "Кепка", block: 3, chance: 18 },
+  { name: "Балаклава", block: 3, chance: 18 },
+  { name: "Кожаный шлем", block: 5, chance: 15 },
+  { name: "Шлем Респиратор", block: 5, chance: 14 },
+  { name: "Велосипедный шлем", block: 5, chance: 15 },
+  { name: "Строительный шлем", block: 10, chance: 10 },
+  { name: "Противогаз", block: 20, chance: 6 },
+  { name: "Шлем пила", block: 20, chance: 4 },
+  { name: "Боевой шлем", block: 20, chance: 5 },
+  { name: "Военный шлем", block: 30, chance: 3 },
+  { name: "Шлем ночного видения", block: 25, chance: 2 },
+  { name: "Шлем стальной", block: 35, chance: 1.5 },
+  { name: "Шлем CRIMECORE", block: 40, chance: 2 }
+];
+
+export const mutationItems = [
+  { name: "Зубной", crit: 0.10, chance: 25 },
+  { name: "Кровоточащий", crit: 0.15, chance: 20 },
+  { name: "Порезанный", crit: 0.15, chance: 20 },
+  { name: "Молчаливый", crit: 0.20, chance: 18 },
+  { name: "Аниме", crit: 0.20, chance: 15 },
+  { name: "Момо", crit: 0.20, chance: 15 },
+  { name: "Безликий", crit: 0.25, chance: 12 },
+  { name: "Зубастик", crit: 0.30, chance: 10 },
+  { name: "Клешни", crit: 0.30, chance: 6 },
+  { name: "Бог", crit: 0.50, chance: 2 }
+];
+
+export const extraItems = [
+  { name: "Фотоаппарат со вспышкой", effect: "stun2", chance: 20, turns: 2 },
+  { name: "Слеповая граната", effect: "stun2", chance: 20, turns: 2 },
+  { name: "Петарда", effect: "damage50", chance: 20 },
+  { name: "Граната", effect: "damage100", chance: 15 },
+  { name: "Адреналин", effect: "halfDamage1", chance: 12, turns: 1 },
+  { name: "Газовый балон", effect: "doubleDamage1", chance: 6, turns: 1 },
+];
+
+export const signItems = [
+  { name: "Знак внимание", kind: "sign", vampirism: 0.10, caseEligible: true },
+  { name: "Знак череп", kind: "sign", vampirism: 0.15, caseEligible: true },
+  { name: "Знак 18+", kind: "sign", vampirism: 0.20, caseEligible: true },
+  { name: "Знак CRIMECORE", kind: "sign", vampirism: 0.25, caseEligible: true },
+  { name: "Знак BIOHAZARD", kind: "sign", vampirism: 0.30, caseEligible: true },
+  { name: "Знак радиации", kind: "sign", preventLethal: "radiation", extraTurn: true, caseEligible: true },
+  { name: "Знак пустой", kind: "sign", dodgeChance: 0.20, caseEligible: true },
+  { name: "Знак final CRIMECORE", kind: "sign", preventLethal: "final", fullHeal: true, caseEligible: false }
+];
+
+const ITEM_DEFINITIONS = {
+  armor: armorItems,
+  weapon: weaponItems,
+  helmet: helmetItems,
+  mutation: mutationItems,
+  extra: extraItems,
+  sign: signItems
+};
+
+export const getItemNamesByCategory = () => (
+  Object.fromEntries(
+    Object.entries(ITEM_DEFINITIONS).map(([category, items]) => [
+      category,
+      items.map((item) => item.name)
+    ])
+  )
+);
+
+export const getAllItemDefinitions = () => ITEM_DEFINITIONS;

--- a/test/item-images.test.js
+++ b/test/item-images.test.js
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getItemNamesByCategory,
+  getItemImageMap,
+  normalizeItemName
+} from '../lib/items.js';
+
+process.env.NODE_ENV = 'test';
+
+test('every configured item has an associated image asset', () => {
+  const categories = getItemNamesByCategory();
+  const imageMap = getItemImageMap();
+
+  for (const [category, names] of Object.entries(categories)) {
+    for (const name of names) {
+      const key = normalizeItemName(name);
+      assert.ok(
+        imageMap[key],
+        `Изображение не найдено для категории "${category}" и предмета "${name}"`
+      );
+    }
+  }
+});

--- a/test/save-data.test.js
+++ b/test/save-data.test.js
@@ -4,6 +4,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+process.env.NODE_ENV = 'test';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 


### PR DESCRIPTION
## Summary
- add a unified database pool that supports Render's PostgreSQL via DATABASE_URL while keeping the MySQL fallback
- extract item definitions and image mapping helpers into a shared module used by the bot runtime
- add regression tests that ensure every item has an associated image asset and tighten NODE_ENV handling in persistence tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d183cab944832a8b4681c0378783b7