### PR TITLE
Use global fetch fallback when node-fetch is unavailable

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,25 @@ try {
     throw error;
   }
 }
-import fetch from 'node-fetch';
+let fetchImpl = globalThis.fetch;
+if (!fetchImpl) {
+  try {
+    const fetchModule = await import('node-fetch');
+    fetchImpl = fetchModule?.default || fetchModule;
+  } catch (error) {
+    if (error?.code === 'ERR_MODULE_NOT_FOUND') {
+      console.warn(
+        'Neither global fetch nor node-fetch are available; remote requests will fail.'
+      );
+    } else {
+      throw error;
+    }
+  }
+}
+const fetch = fetchImpl ? (...args) => fetchImpl(...args) : async () => {
+  throw new Error('Fetch API is unavailable.');
+};
+
 import http from 'http';
 
 let TelegramBotCtorCache;


### PR DESCRIPTION
## Summary
- use the built-in fetch implementation when present and only import node-fetch as a fallback
- add a clear warning when neither fetch implementation can be loaded so remote requests fail gracefully

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d18f307588832a9b1c2e4d364955d0