### PR TITLE
Handle missing dotenv dependency gracefully

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,5 +1,14 @@
-import dotenv from 'dotenv';
-dotenv.config();
+try {
+  const dotenvModule = await import('dotenv');
+  const dotenv = dotenvModule.default || dotenvModule;
+  if (typeof dotenv.config === 'function') {
+    dotenv.config();
+  }
+} catch (err) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn('Не удалось загрузить dotenv:', err.message);
+  }
+}
 
 const noopPool = {
   dialect: 'memory',


### PR DESCRIPTION
## Summary
- load dotenv lazily with a dynamic import so the bot can start even when the package is unavailable
- log a warning in non-production environments if dotenv fails to load

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d19077c080832aa6dc35c0e6ff2e58