### PR TITLE
Gracefully handle missing Telegram bot dependencies

### DIFF
--- a/lib/telegramBotCompat.js
+++ b/lib/telegramBotCompat.js
@@ -1,5 +1,34 @@
 import { EventEmitter } from 'node:events';
-import { Bot } from 'grammy';
+
+let GrammyBotClass = null;
+let grammyLoadError = null;
+
+try {
+  const grammyModule = await import('grammy');
+  const maybeBot =
+    grammyModule?.Bot ||
+    grammyModule?.default?.Bot ||
+    (typeof grammyModule?.default === 'function' ? grammyModule.default : null);
+  if (typeof maybeBot === 'function') {
+    GrammyBotClass = maybeBot;
+  } else {
+    grammyLoadError = new Error('Grammy module did not export a Bot constructor.');
+  }
+} catch (error) {
+  if (error?.code === 'ERR_MODULE_NOT_FOUND') {
+    grammyLoadError = error;
+  } else {
+    throw error;
+  }
+}
+
+export function isGrammyAvailable() {
+  return Boolean(GrammyBotClass);
+}
+
+export function getGrammyLoadError() {
+  return grammyLoadError;
+}
 
 export default class TelegramBotCompat extends EventEmitter {
   constructor(token, options = {}) {
@@ -7,10 +36,13 @@ export default class TelegramBotCompat extends EventEmitter {
     if (!token) {
       throw new Error('Telegram token is required');
     }
+    if (!GrammyBotClass) {
+      throw new Error('Grammy Bot is not available.');
+    }
     this.token = token;
     this.options = options;
     this.textHandlers = [];
-    this.bot = new Bot(token, options.grammyOptions || {});
+    this.bot = new GrammyBotClass(token, options.grammyOptions || {});
     this.bot.catch((err) => {
       this.emit('polling_error', err);
       console.error('Grammy error:', err);
@@ -159,5 +191,95 @@ export default class TelegramBotCompat extends EventEmitter {
 
   getChatMember(chatId, userId) {
     return this.bot.api.getChatMember(chatId, userId);
+  }
+}
+
+export class TelegramBotNoop extends EventEmitter {
+  constructor(token, options = {}) {
+    super();
+    this.token = token;
+    this.options = options;
+    this.textHandlers = [];
+    this._warn('Telegram functionality is disabled because no bot backend is available.');
+  }
+
+  _warn(message) {
+    console.warn(`[TelegramBotNoop] ${message}`);
+  }
+
+  onText(regexp, callback) {
+    if (regexp instanceof RegExp && typeof callback === 'function') {
+      this.textHandlers.push({ regexp, callback });
+    }
+    this._warn('onText called but will not receive updates.');
+  }
+
+  _resolve(value) {
+    return Promise.resolve(value);
+  }
+
+  startPolling() {
+    this._warn('startPolling called but no polling will occur.');
+    return this._resolve();
+  }
+
+  stopPolling() {
+    this._warn('stopPolling called but no polling was active.');
+    return this._resolve();
+  }
+
+  setMyCommands() {
+    this._warn('setMyCommands is unavailable.');
+    return this._resolve();
+  }
+
+  sendMessage() {
+    this._warn('sendMessage is unavailable.');
+    return this._resolve(null);
+  }
+
+  sendPhoto() {
+    this._warn('sendPhoto is unavailable.');
+    return this._resolve(null);
+  }
+
+  editMessageText() {
+    this._warn('editMessageText is unavailable.');
+    return this._resolve(null);
+  }
+
+  editMessageCaption() {
+    this._warn('editMessageCaption is unavailable.');
+    return this._resolve(null);
+  }
+
+  editMessageReplyMarkup() {
+    this._warn('editMessageReplyMarkup is unavailable.');
+    return this._resolve(null);
+  }
+
+  deleteMessage() {
+    this._warn('deleteMessage is unavailable.');
+    return this._resolve(false);
+  }
+
+  answerCallbackQuery() {
+    this._warn('answerCallbackQuery is unavailable.');
+    return this._resolve();
+  }
+
+  answerPreCheckoutQuery() {
+    this._warn('answerPreCheckoutQuery is unavailable.');
+    return this._resolve();
+  }
+
+  sendInvoice() {
+    this._warn('sendInvoice is unavailable.');
+    return this._resolve();
+  }
+
+  getChatMember() {
+    this._warn('getChatMember is unavailable.');
+    return this._resolve(null);
   }
 }


### PR DESCRIPTION
## Summary
- load grammy lazily inside the Telegram compatibility layer and report initialization issues instead of crashing when it is absent
- provide a no-op Telegram bot implementation so the app can still start when neither node-telegram-bot-api nor grammy are installed
- update the runtime fallback logic to select the compatibility or no-op bots based on availability and surface clear warnings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d191e0b7b4832ab36e5358fe2c8e07