### PR TITLE
Gracefully handle missing database drivers

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,13 +1,23 @@
-try {
-  const dotenvModule = await import('dotenv');
+async function optionalImport(specifier) {
+  try {
+    const module = await import(specifier);
+    return { module };
+  } catch (error) {
+    if (error?.code === 'ERR_MODULE_NOT_FOUND') {
+      return { module: null, error };
+    }
+    throw error;
+  }
+}
+
+const { module: dotenvModule, error: dotenvError } = await optionalImport('dotenv');
+if (dotenvModule) {
   const dotenv = dotenvModule.default || dotenvModule;
   if (typeof dotenv.config === 'function') {
     dotenv.config();
   }
-} catch (err) {
-  if (process.env.NODE_ENV !== 'production') {
-    console.warn('Не удалось загрузить dotenv:', err.message);
-  }
+} else if (dotenvError && process.env.NODE_ENV !== 'production') {
+  console.warn('Не удалось загрузить dotenv:', dotenvError.message);
 }
 
 const noopPool = {
@@ -26,9 +36,14 @@ const noopPool = {
 let pool = noopPool;
 
 if (process.env.NODE_ENV !== 'test') {
-  if (process.env.DATABASE_URL) {
-    try {
-      const pgModule = await import('pg');
+  const hasPostgresConfig = Boolean(process.env.DATABASE_URL);
+  const requiredMysqlEnv = ['DB_HOST', 'DB_USER', 'DB_NAME'];
+  const hasAllMysqlEnv = requiredMysqlEnv.every((key) => process.env[key]);
+  const hasAnyMysqlEnv = requiredMysqlEnv.some((key) => process.env[key]);
+
+  if (hasPostgresConfig) {
+    const { module: pgModule, error } = await optionalImport('pg');
+    if (pgModule?.Pool) {
       const { Pool } = pgModule;
       const pgPool = new Pool({
         connectionString: process.env.DATABASE_URL,
@@ -62,12 +77,14 @@ if (process.env.NODE_ENV !== 'test') {
           await pgPool.end();
         }
       };
-    } catch (err) {
-      console.error('Ошибка инициализации PostgreSQL:', err);
+    } else if (error) {
+      console.warn(
+        'PostgreSQL драйвер pg недоступен; использование базы данных отключено. Падение в режим памяти.'
+      );
     }
-  } else {
-    try {
-      const mysqlModule = await import('mysql2/promise');
+  } else if (hasAllMysqlEnv) {
+    const { module: mysqlModule, error } = await optionalImport('mysql2/promise');
+    if (mysqlModule) {
       const mysql = mysqlModule.default || mysqlModule;
       const mysqlPool = mysql.createPool({
         host: process.env.DB_HOST,
@@ -93,9 +110,15 @@ if (process.env.NODE_ENV !== 'test') {
           return mysqlPool.end();
         }
       };
-    } catch (err) {
-      console.error('Ошибка инициализации MySQL:', err);
+    } else if (error) {
+      console.warn(
+        'MySQL драйвер mysql2 недоступен; использование базы данных отключено. Падение в режим памяти.'
+      );
     }
+  } else if (hasAnyMysqlEnv) {
+    console.warn(
+      'Переменные окружения MySQL указаны не полностью; падение в режим памяти.'
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- add a shared optional import helper for database drivers and dotenv loading
- avoid crashing or emitting stack traces when pg or mysql2 are absent and fall back to the in-memory pool with clear warnings
- require full MySQL configuration before attempting to load mysql2 to prevent noisy errors in partially configured environments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d198ce1020832a97dfe013dbf622c0