### PR TITLE
Add resilient env loading and Telegram fallback client

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,23 +1,9 @@
-async function optionalImport(specifier) {
-  try {
-    const module = await import(specifier);
-    return { module };
-  } catch (error) {
-    if (error?.code === 'ERR_MODULE_NOT_FOUND') {
-      return { module: null, error };
-    }
-    throw error;
-  }
-}
+import { ensureEnvConfig } from './env.js';
+import { optionalImport } from './optionalImport.js';
 
-const { module: dotenvModule, error: dotenvError } = await optionalImport('dotenv');
-if (dotenvModule) {
-  const dotenv = dotenvModule.default || dotenvModule;
-  if (typeof dotenv.config === 'function') {
-    dotenv.config();
-  }
-} else if (dotenvError && process.env.NODE_ENV !== 'production') {
-  console.warn('Не удалось загрузить dotenv:', dotenvError.message);
+const envResult = await ensureEnvConfig({ quiet: true });
+if (!envResult.loaded && envResult.error && process.env.NODE_ENV !== 'production') {
+  console.warn('Не удалось загрузить dotenv:', envResult.error.message);
 }
 
 const noopPool = {

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,0 +1,105 @@
+import fs from 'fs';
+import path from 'path';
+import { optionalImport } from './optionalImport.js';
+
+let cachedResult = null;
+
+function parseLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) {
+    return null;
+  }
+  const exportPrefix = 'export ';
+  const normalized = trimmed.startsWith(exportPrefix)
+    ? trimmed.slice(exportPrefix.length)
+    : trimmed;
+  const match = normalized.match(/^[^=]+=/);
+  if (!match) {
+    return null;
+  }
+  const key = match[0].slice(0, -1).trim();
+  let value = normalized.slice(match[0].length);
+  const commentIndex = (() => {
+    let escaped = false;
+    for (let i = 0; i < value.length; i += 1) {
+      const char = value[i];
+      if (char === '\\' && !escaped) {
+        escaped = true;
+        continue;
+      }
+      if (char === '#' && !escaped) {
+        return i;
+      }
+      escaped = false;
+    }
+    return -1;
+  })();
+  if (commentIndex !== -1) {
+    value = value.slice(0, commentIndex);
+  }
+  value = value.trim();
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1);
+  }
+  value = value.replace(/\\n/g, '\n').replace(/\\r/g, '\r');
+  return { key, value };
+}
+
+function parseEnv(content) {
+  const envMap = {};
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    const parsed = parseLine(line);
+    if (!parsed) continue;
+    envMap[parsed.key] = parsed.value;
+  }
+  return envMap;
+}
+
+async function loadFromFile(options = {}) {
+  const envPath = options.path
+    ? path.resolve(options.path)
+    : path.join(process.cwd(), '.env');
+  try {
+    const content = await fs.promises.readFile(envPath, 'utf8');
+    const parsed = parseEnv(content);
+    const override = Boolean(options.override);
+    for (const [key, value] of Object.entries(parsed)) {
+      if (process.env[key] === undefined || override) {
+        process.env[key] = value;
+      }
+    }
+    return { loaded: true, source: 'fallback', path: envPath };
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return { loaded: false, source: null, path: envPath, error };
+    }
+    throw error;
+  }
+}
+
+export async function ensureEnvConfig(options = {}) {
+  if (cachedResult && !options.force) {
+    return cachedResult;
+  }
+
+  const dotenvAttempt = await optionalImport('dotenv');
+  if (dotenvAttempt.module && typeof dotenvAttempt.module.config === 'function') {
+    const dotenv = dotenvAttempt.module.default || dotenvAttempt.module;
+    const result = dotenv.config(options);
+    cachedResult = { loaded: true, source: 'dotenv', result };
+    return cachedResult;
+  }
+
+  const fallback = await loadFromFile(options);
+  if (!fallback.loaded && dotenvAttempt.error && !options.quiet) {
+    const message = dotenvAttempt.error?.message || 'dotenv package not found.';
+    console.warn(`Failed to load dotenv package (${message}); falling back to manual parser.`);
+  }
+  cachedResult = fallback;
+  return cachedResult;
+}
+
+export function resetEnvCache() {
+  cachedResult = null;
+}

--- a/lib/optionalImport.js
+++ b/lib/optionalImport.js
@@ -1,0 +1,34 @@
+import { createRequire } from 'module';
+
+const nodeRequire = createRequire(import.meta.url);
+
+function isModuleNotFoundError(error) {
+  if (!error) return false;
+  if (error.code === 'ERR_MODULE_NOT_FOUND' || error.code === 'MODULE_NOT_FOUND') {
+    return true;
+  }
+  if (typeof error.message === 'string') {
+    return /Cannot find module|Cannot find package/.test(error.message);
+  }
+  return false;
+}
+
+export async function optionalImport(specifier) {
+  try {
+    const imported = await import(specifier);
+    return { module: imported };
+  } catch (importError) {
+    if (!isModuleNotFoundError(importError)) {
+      throw importError;
+    }
+    try {
+      const required = nodeRequire(specifier);
+      return { module: required, error: importError };
+    } catch (requireError) {
+      if (isModuleNotFoundError(requireError)) {
+        return { module: null, error: importError };
+      }
+      throw requireError;
+    }
+  }
+}

--- a/lib/simpleTelegramBot.js
+++ b/lib/simpleTelegramBot.js
@@ -1,0 +1,304 @@
+import { EventEmitter } from 'node:events';
+import { Blob } from 'buffer';
+
+function toJSON(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'object' && value !== null && 'toJSON' in value) {
+    return value.toJSON();
+  }
+  return value;
+}
+
+function buildFormData(payload) {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(payload)) {
+    if (value === undefined || value === null) continue;
+    if (Buffer.isBuffer(value)) {
+      formData.append(key, new Blob([value]), `${key}.bin`);
+      continue;
+    }
+    if (typeof value === 'object') {
+      formData.append(key, JSON.stringify(value));
+      continue;
+    }
+    formData.append(key, value);
+  }
+  return formData;
+}
+
+export default class SimpleTelegramBot extends EventEmitter {
+  constructor(token, options = {}) {
+    super();
+    if (!token) {
+      throw new Error('Telegram token is required');
+    }
+    this.token = token;
+    this.options = options;
+    this.textHandlers = [];
+    this.apiBase = options.apiBase || `https://api.telegram.org/bot${token}`;
+    const fetchImpl = options.httpFetch || globalThis.fetch;
+    if (!fetchImpl) {
+      throw new Error('Fetch implementation is required for SimpleTelegramBot');
+    }
+    this._fetch = (...args) => fetchImpl(...args);
+    this._isPolling = false;
+    this._offset = 0;
+    this._pollingPromise = null;
+    this._pollingController = null;
+    this._pollingInterval = Math.max(0, Number(options.polling?.interval ?? 0));
+    this._pollingTimeout = Math.max(0, Number(options.polling?.timeout ?? 30));
+    this._dropPendingUpdates = options.polling?.dropPendingUpdates ?? true;
+    this._allowedUpdates = options.polling?.allowedUpdates;
+
+    if (options.polling) {
+      this.startPolling().catch((error) => {
+        this.emit('polling_error', error);
+        console.error('Failed to start SimpleTelegramBot polling:', error);
+      });
+    }
+  }
+
+  onText(regexp, callback) {
+    if (!(regexp instanceof RegExp)) {
+      throw new TypeError('regexp must be an instance of RegExp');
+    }
+    if (typeof callback !== 'function') {
+      throw new TypeError('callback must be a function');
+    }
+    this.textHandlers.push({ regexp, callback });
+  }
+
+  async startPolling() {
+    if (this._isPolling) {
+      return this._pollingPromise;
+    }
+    this._isPolling = true;
+    this._pollingPromise = this._pollingLoop();
+    return this._pollingPromise;
+  }
+
+  async stopPolling() {
+    this._isPolling = false;
+    if (this._pollingController) {
+      this._pollingController.abort();
+      this._pollingController = null;
+    }
+    if (this._pollingPromise) {
+      try {
+        await this._pollingPromise;
+      } catch (error) {
+        // ignore errors caused by aborting the request
+        if (error.name !== 'AbortError') {
+          throw error;
+        }
+      } finally {
+        this._pollingPromise = null;
+      }
+    }
+  }
+
+  async setMyCommands(commands) {
+    return this._call('setMyCommands', { commands });
+  }
+
+  sendMessage(chatId, text, options = {}) {
+    return this._call('sendMessage', { chat_id: chatId, text, ...options });
+  }
+
+  sendPhoto(chatId, photo, options = {}) {
+    const payload = { chat_id: chatId, ...options };
+    if (Buffer.isBuffer(photo)) {
+      payload.photo = photo;
+      return this._call('sendPhoto', payload, { useFormData: true });
+    }
+    return this._call('sendPhoto', { ...payload, photo });
+  }
+
+  editMessageText(text, options = {}) {
+    return this._call('editMessageText', { text, ...options });
+  }
+
+  editMessageCaption(caption, options = {}) {
+    return this._call('editMessageCaption', { caption, ...options });
+  }
+
+  editMessageReplyMarkup(markup, options = {}) {
+    return this._call('editMessageReplyMarkup', { reply_markup: markup, ...options });
+  }
+
+  deleteMessage(chatId, messageId, options = {}) {
+    return this._call('deleteMessage', { chat_id: chatId, message_id: messageId, ...options });
+  }
+
+  answerCallbackQuery(callbackQueryId, options = {}) {
+    return this._call('answerCallbackQuery', { callback_query_id: callbackQueryId, ...options });
+  }
+
+  answerPreCheckoutQuery(preCheckoutQueryId, ok, options = {}) {
+    if (typeof ok === 'object') {
+      return this._call('answerPreCheckoutQuery', { pre_checkout_query_id: preCheckoutQueryId, ...ok });
+    }
+    return this._call('answerPreCheckoutQuery', {
+      pre_checkout_query_id: preCheckoutQueryId,
+      ok,
+      ...options
+    });
+  }
+
+  sendInvoice(
+    chatId,
+    title,
+    description,
+    payload,
+    providerToken,
+    startParameter,
+    currency,
+    prices,
+    options = {}
+  ) {
+    return this._call('sendInvoice', {
+      chat_id: chatId,
+      title,
+      description,
+      payload,
+      provider_token: providerToken,
+      start_parameter: startParameter,
+      currency,
+      prices,
+      ...options
+    });
+  }
+
+  getChatMember(chatId, userId) {
+    return this._call('getChatMember', { chat_id: chatId, user_id: userId });
+  }
+
+  _processTextHandlers(msg) {
+    const text = msg && msg.text;
+    if (typeof text !== 'string') return;
+    for (const handler of this.textHandlers) {
+      const match = handler.regexp.exec(text);
+      if (match) {
+        try {
+          handler.callback(msg, match);
+        } catch (error) {
+          console.error('Error in SimpleTelegramBot onText handler:', error);
+        }
+      }
+      handler.regexp.lastIndex = 0;
+    }
+  }
+
+  async _pollingLoop() {
+    if (this._dropPendingUpdates) {
+      try {
+        await this._discardPendingUpdates();
+      } catch (error) {
+        this.emit('polling_error', error);
+      }
+    }
+    while (this._isPolling) {
+      try {
+        const updates = await this._getUpdates();
+        for (const update of updates) {
+          this._handleUpdate(update);
+          this._offset = update.update_id + 1;
+        }
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          break;
+        }
+        this.emit('polling_error', error);
+        await this._sleep(1000);
+      }
+      if (this._pollingInterval > 0) {
+        await this._sleep(this._pollingInterval);
+      }
+    }
+  }
+
+  async _discardPendingUpdates() {
+    const updates = await this._call('getUpdates', { offset: -1, limit: 1, timeout: 0 });
+    if (Array.isArray(updates) && updates.length > 0) {
+      this._offset = updates[updates.length - 1].update_id + 1;
+    }
+  }
+
+  async _getUpdates() {
+    const payload = {
+      offset: this._offset,
+      timeout: this._pollingTimeout,
+      allowed_updates: this._allowedUpdates
+    };
+    this._pollingController = new AbortController();
+    try {
+      return await this._call('getUpdates', payload, {
+        signal: this._pollingController.signal
+      });
+    } finally {
+      this._pollingController = null;
+    }
+  }
+
+  async _call(method, payload = {}, options = {}) {
+    const url = `${this.apiBase}/${method}`;
+    const { useFormData = false, signal } = options;
+    let fetchOptions;
+    if (useFormData) {
+      const formData = buildFormData(payload);
+      fetchOptions = { method: 'POST', body: formData, signal };
+    } else {
+      const sanitized = {};
+      for (const [key, value] of Object.entries(payload)) {
+        if (value !== undefined) {
+          sanitized[key] = toJSON(value);
+        }
+      }
+      fetchOptions = {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(sanitized),
+        signal
+      };
+    }
+    const response = await this._fetch(url, fetchOptions);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Telegram API HTTP error ${response.status}: ${text}`);
+    }
+    const data = await response.json();
+    if (!data.ok) {
+      throw new Error(data.description || 'Telegram API responded with an error');
+    }
+    return data.result;
+  }
+
+  _handleUpdate(update) {
+    if (!update || typeof update !== 'object') return;
+    if (update.message) {
+      this.emit('message', update.message);
+      this._processTextHandlers(update.message);
+    }
+    if (update.edited_message) {
+      this.emit('edited_message', update.edited_message);
+    }
+    if (update.callback_query) {
+      this.emit('callback_query', update.callback_query);
+    }
+    if (update.pre_checkout_query) {
+      this.emit('pre_checkout_query', update.pre_checkout_query);
+    }
+    if (update.shipping_query) {
+      this.emit('shipping_query', update.shipping_query);
+    }
+    if (update.my_chat_member) {
+      this.emit('my_chat_member', update.my_chat_member);
+    }
+  }
+
+  _sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/lib/telegramBotCompat.js
+++ b/lib/telegramBotCompat.js
@@ -1,10 +1,11 @@
 import { EventEmitter } from 'node:events';
+import { optionalImport } from './optionalImport.js';
 
 let GrammyBotClass = null;
 let grammyLoadError = null;
 
-try {
-  const grammyModule = await import('grammy');
+const { module: grammyModule, error: grammyError } = await optionalImport('grammy');
+if (grammyModule) {
   const maybeBot =
     grammyModule?.Bot ||
     grammyModule?.default?.Bot ||
@@ -14,12 +15,8 @@ try {
   } else {
     grammyLoadError = new Error('Grammy module did not export a Bot constructor.');
   }
-} catch (error) {
-  if (error?.code === 'ERR_MODULE_NOT_FOUND') {
-    grammyLoadError = error;
-  } else {
-    throw error;
-  }
+} else if (grammyError) {
+  grammyLoadError = grammyError;
 }
 
 export function isGrammyAvailable() {


### PR DESCRIPTION
## Summary
- add a shared optional import helper with require fallback and use it for environment loading, Telegram setup, and database drivers
- introduce a lightweight dotenv fallback loader so missing dotenv no longer blocks configuration
- implement a built-in HTTP-based Telegram bot client and wire it in as a fallback when external Telegram libraries are unavailable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d19adacc68832ab21e266f56f7283d