### PR TITLE
Gracefully handle missing pngjs composer

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,9 +41,22 @@ if (!sharp) {
 if (!sharp && !JimpLib) {
   try {
     const pngComposerModule = await import('./lib/pngComposer.js');
+    const isAvailable = pngComposerModule?.isPngComposerAvailable?.();
     composePngBuffers = pngComposerModule?.composePngBuffers;
-    if (composePngBuffers) {
+    if (composePngBuffers && isAvailable) {
       console.info('Using pngjs fallback for inventory image composition.');
+    } else {
+      const reason = pngComposerModule?.getPngComposerLoadError?.();
+      if (reason) {
+        const message = reason?.message || String(reason);
+        console.warn(
+          `pngjs is unavailable (${message}); inventory image generation will be skipped.`
+        );
+      } else if (isAvailable === false) {
+        console.warn('pngjs fallback is unavailable; inventory image generation will be skipped.');
+      } else {
+        console.warn('pngjs fallback could not be initialized; inventory image generation will be skipped.');
+      }
     }
   } catch (pngComposerError) {
     console.warn('Failed to load pngjs fallback for inventory image composition:', pngComposerError);

--- a/lib/pngComposer.js
+++ b/lib/pngComposer.js
@@ -1,4 +1,42 @@
-import { PNG } from 'pngjs';
+import { optionalImport } from './optionalImport.js';
+
+let PNGModule = null;
+let pngjsLoadError = null;
+
+try {
+  const { module: pngjsModule, error } = await optionalImport('pngjs');
+  pngjsLoadError = error || null;
+  if (pngjsModule) {
+    const candidates = [pngjsModule, pngjsModule?.default];
+    for (const candidate of candidates) {
+      if (candidate?.PNG?.sync) {
+        PNGModule = candidate.PNG;
+        break;
+      }
+      if (candidate?.default?.sync) {
+        PNGModule = candidate.default;
+        break;
+      }
+      if (candidate?.sync) {
+        PNGModule = candidate;
+        break;
+      }
+    }
+  }
+} catch (error) {
+  pngjsLoadError = error;
+  PNGModule = null;
+}
+
+if (!PNGModule && !pngjsLoadError) {
+  pngjsLoadError = new Error('pngjs module does not expose a PNG export.');
+}
+
+const PNG = PNGModule;
+
+export const isPngComposerAvailable = () => Boolean(PNG);
+
+export const getPngComposerLoadError = () => pngjsLoadError;
 
 function blendPixel(base, overlay) {
   const oa = overlay[3] / 255;
@@ -28,49 +66,51 @@ function blendPixel(base, overlay) {
   return [r, g, b, a];
 }
 
-export function composePngBuffers(baseBuffer, overlayBuffers = []) {
-  if (!Buffer.isBuffer(baseBuffer)) {
-    baseBuffer = Buffer.from(baseBuffer);
-  }
+export const composePngBuffers = !PNG
+  ? null
+  : function composePngBuffers(baseBuffer, overlayBuffers = []) {
+    if (!Buffer.isBuffer(baseBuffer)) {
+      baseBuffer = Buffer.from(baseBuffer);
+    }
 
-  const basePng = PNG.sync.read(baseBuffer);
+    const basePng = PNG.sync.read(baseBuffer);
 
-  if (!overlayBuffers?.length) {
+    if (!overlayBuffers?.length) {
+      return PNG.sync.write(basePng);
+    }
+
+    for (const buffer of overlayBuffers) {
+      if (!buffer) continue;
+
+      const normalizedBuffer = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
+      const overlayPng = PNG.sync.read(normalizedBuffer);
+
+      if (
+        overlayPng.width !== basePng.width ||
+        overlayPng.height !== basePng.height
+      ) {
+        throw new Error(
+          `Overlay dimensions ${overlayPng.width}x${overlayPng.height} do not match base ${basePng.width}x${basePng.height}`
+        );
+      }
+
+      const { data: baseData } = basePng;
+      const { data: overlayData } = overlayPng;
+
+      for (let i = 0; i < baseData.length; i += 4) {
+        const blended = blendPixel(
+          baseData.subarray(i, i + 4),
+          overlayData.subarray(i, i + 4)
+        );
+
+        baseData[i] = blended[0];
+        baseData[i + 1] = blended[1];
+        baseData[i + 2] = blended[2];
+        baseData[i + 3] = blended[3];
+      }
+    }
+
     return PNG.sync.write(basePng);
-  }
-
-  for (const buffer of overlayBuffers) {
-    if (!buffer) continue;
-
-    const normalizedBuffer = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
-    const overlayPng = PNG.sync.read(normalizedBuffer);
-
-    if (
-      overlayPng.width !== basePng.width ||
-      overlayPng.height !== basePng.height
-    ) {
-      throw new Error(
-        `Overlay dimensions ${overlayPng.width}x${overlayPng.height} do not match base ${basePng.width}x${basePng.height}`
-      );
-    }
-
-    const { data: baseData } = basePng;
-    const { data: overlayData } = overlayPng;
-
-    for (let i = 0; i < baseData.length; i += 4) {
-      const blended = blendPixel(
-        baseData.subarray(i, i + 4),
-        overlayData.subarray(i, i + 4)
-      );
-
-      baseData[i] = blended[0];
-      baseData[i + 1] = blended[1];
-      baseData[i + 2] = blended[2];
-      baseData[i + 3] = blended[3];
-    }
-  }
-
-  return PNG.sync.write(basePng);
-}
+  };
 
 export default composePngBuffers;


### PR DESCRIPTION
## Summary
- load pngjs through the optional import helper and expose availability/error helpers
- return a null composer when pngjs is absent so the module can load without crashing
- surface clearer logging when the pngjs fallback cannot be initialized

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1a5bd3488832a82bc54a3348ace47