### PR TITLE
Improve optional module resolution

### DIFF
--- a/lib/optionalImport.js
+++ b/lib/optionalImport.js
@@ -1,10 +1,40 @@
+import path from 'path';
+import { pathToFileURL } from 'url';
 import { createRequire } from 'module';
 
-const nodeRequire = createRequire(import.meta.url);
+const requireContexts = [];
+
+function pushRequireContext(basePath) {
+  try {
+    const req = createRequire(basePath);
+    if (!requireContexts.includes(req)) {
+      requireContexts.push(req);
+    }
+  } catch (err) {
+    if (!isModuleNotFoundError(err) && err.code !== 'ERR_INVALID_MODULE_SPECIFIER') {
+      throw err;
+    }
+  }
+}
+
+pushRequireContext(import.meta.url);
+
+try {
+  const cwd = process.cwd();
+  if (cwd) {
+    const pkgJsonPath = path.join(cwd, 'package.json');
+    pushRequireContext(pkgJsonPath);
+  }
+} catch (err) {
+  // Ignore errors from process.cwd(); we'll fall back to the default context.
+}
 
 function isModuleNotFoundError(error) {
   if (!error) return false;
   if (error.code === 'ERR_MODULE_NOT_FOUND' || error.code === 'MODULE_NOT_FOUND') {
+    return true;
+  }
+  if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
     return true;
   }
   if (typeof error.message === 'string') {
@@ -14,6 +44,25 @@ function isModuleNotFoundError(error) {
 }
 
 export async function optionalImport(specifier) {
+  let lastModuleNotFoundError = null;
+
+  for (const req of requireContexts) {
+    try {
+      const required = req(specifier);
+      return { module: required };
+    } catch (requireError) {
+      if (requireError?.code === 'ERR_REQUIRE_ESM') {
+        lastModuleNotFoundError = requireError;
+        continue;
+      }
+      if (isModuleNotFoundError(requireError)) {
+        lastModuleNotFoundError = requireError;
+        continue;
+      }
+      throw requireError;
+    }
+  }
+
   try {
     const imported = await import(specifier);
     return { module: imported };
@@ -21,14 +70,29 @@ export async function optionalImport(specifier) {
     if (!isModuleNotFoundError(importError)) {
       throw importError;
     }
+    lastModuleNotFoundError = importError;
+  }
+
+  for (const req of requireContexts) {
     try {
-      const required = nodeRequire(specifier);
-      return { module: required, error: importError };
-    } catch (requireError) {
-      if (isModuleNotFoundError(requireError)) {
-        return { module: null, error: importError };
+      const resolvedPath = req.resolve(specifier);
+      const resolvedUrl = pathToFileURL(resolvedPath).href;
+      const imported = await import(resolvedUrl);
+      return { module: imported };
+    } catch (resolveError) {
+      if (resolveError?.code === 'ERR_REQUIRE_ESM') {
+        lastModuleNotFoundError = resolveError;
+        continue;
       }
-      throw requireError;
+      if (isModuleNotFoundError(resolveError)) {
+        lastModuleNotFoundError = resolveError;
+        continue;
+      }
+      throw resolveError;
     }
   }
+
+  const fallbackError =
+    lastModuleNotFoundError || new Error(`Optional module "${specifier}" could not be resolved.`);
+  return { module: null, error: fallbackError };
 }


### PR DESCRIPTION
## Summary
- expand optional module resolution to reuse multiple require contexts, including the project root, before falling back to dynamic import
- fall back to resolved file URLs when necessary and provide clearer errors when no loader succeeds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1a7855a60832a8b98690588a65d4d