### PR TITLE
Add built-in PNG composer fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,14 @@ if (!sharp && !JimpLib) {
     const isAvailable = pngComposerModule?.isPngComposerAvailable?.();
     composePngBuffers = pngComposerModule?.composePngBuffers;
     if (composePngBuffers && isAvailable) {
-      console.info('Using pngjs fallback for inventory image composition.');
+      const implementation = pngComposerModule?.getPngComposerImplementation?.();
+      if (implementation === 'pngjs') {
+        console.info('Using pngjs fallback for inventory image composition.');
+      } else if (implementation === 'builtin-simple') {
+        console.info('Using built-in PNG compositor for inventory image composition.');
+      } else {
+        console.info('Using PNG fallback for inventory image composition.');
+      }
     } else {
       const reason = pngComposerModule?.getPngComposerLoadError?.();
       if (reason) {

--- a/lib/pngComposer.js
+++ b/lib/pngComposer.js
@@ -2,34 +2,82 @@ import { optionalImport } from './optionalImport.js';
 
 let PNGModule = null;
 let pngjsLoadError = null;
+let composerImplementation = null;
 
-try {
-  const { module: pngjsModule, error } = await optionalImport('pngjs');
-  pngjsLoadError = error || null;
-  if (pngjsModule) {
-    const candidates = [pngjsModule, pngjsModule?.default];
-    for (const candidate of candidates) {
-      if (candidate?.PNG?.sync) {
-        PNGModule = candidate.PNG;
-        break;
-      }
-      if (candidate?.default?.sync) {
-        PNGModule = candidate.default;
-        break;
-      }
-      if (candidate?.sync) {
-        PNGModule = candidate;
-        break;
+const FORCE_SIMPLE = process?.env?.FORCE_SIMPLE_PNG_COMPOSER === '1';
+
+if (!FORCE_SIMPLE) {
+  try {
+    const { module: pngjsModule, error } = await optionalImport('pngjs');
+    pngjsLoadError = error || null;
+    if (pngjsModule) {
+      const candidates = [pngjsModule, pngjsModule?.default];
+      for (const candidate of candidates) {
+        if (candidate?.PNG?.sync) {
+          PNGModule = candidate.PNG;
+          break;
+        }
+        if (candidate?.default?.sync) {
+          PNGModule = candidate.default;
+          break;
+        }
+        if (candidate?.sync) {
+          PNGModule = candidate;
+          break;
+        }
       }
     }
+  } catch (error) {
+    pngjsLoadError = error;
+    PNGModule = null;
   }
-} catch (error) {
-  pngjsLoadError = error;
-  PNGModule = null;
+
+  if (!PNGModule && !pngjsLoadError) {
+    pngjsLoadError = new Error('pngjs module does not expose a PNG export.');
+  }
 }
 
-if (!PNGModule && !pngjsLoadError) {
-  pngjsLoadError = new Error('pngjs module does not expose a PNG export.');
+if (PNGModule) {
+  composerImplementation = 'pngjs';
+}
+
+if (!PNGModule) {
+  try {
+    const simpleModule = await import('./simplePng.js');
+    if (simpleModule?.decodePng && simpleModule?.encodePng) {
+      composerImplementation = 'builtin-simple';
+      PNGModule = {
+        sync: {
+          read(buffer) {
+            const result = simpleModule.decodePng(buffer);
+            return {
+              width: result.width,
+              height: result.height,
+              data: Buffer.from(result.data)
+            };
+          },
+          write(image) {
+            return Buffer.from(
+              simpleModule.encodePng({
+                width: image.width,
+                height: image.height,
+                data: Buffer.from(image.data)
+              })
+            );
+          }
+        }
+      };
+      if (FORCE_SIMPLE && !pngjsLoadError) {
+        pngjsLoadError = new Error('pngjs loading was skipped via FORCE_SIMPLE_PNG_COMPOSER.');
+      }
+    }
+  } catch (simpleError) {
+    if (!pngjsLoadError) {
+      pngjsLoadError = simpleError;
+    }
+    PNGModule = null;
+    composerImplementation = null;
+  }
 }
 
 const PNG = PNGModule;
@@ -37,6 +85,8 @@ const PNG = PNGModule;
 export const isPngComposerAvailable = () => Boolean(PNG);
 
 export const getPngComposerLoadError = () => pngjsLoadError;
+
+export const getPngComposerImplementation = () => composerImplementation;
 
 function blendPixel(base, overlay) {
   const oa = overlay[3] / 255;

--- a/lib/simplePng.js
+++ b/lib/simplePng.js
@@ -1,0 +1,232 @@
+import { inflateSync, deflateSync } from 'node:zlib';
+
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const COLOR_TYPE_RGBA = 6;
+const BIT_DEPTH_8 = 8;
+const BYTES_PER_PIXEL = 4;
+
+const crcTable = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buffer) {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buffer.length; i++) {
+    const byte = buffer[i];
+    crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function readUInt32BE(buffer, offset) {
+  return (
+    (buffer[offset] << 24) |
+    (buffer[offset + 1] << 16) |
+    (buffer[offset + 2] << 8) |
+    buffer[offset + 3]
+  ) >>> 0;
+}
+
+function writeUInt32BE(value) {
+  const buf = Buffer.alloc(4);
+  buf[0] = (value >>> 24) & 0xff;
+  buf[1] = (value >>> 16) & 0xff;
+  buf[2] = (value >>> 8) & 0xff;
+  buf[3] = value & 0xff;
+  return buf;
+}
+
+function parseChunks(buffer) {
+  if (!buffer || buffer.length < PNG_SIGNATURE.length) {
+    throw new Error('PNG buffer is too small.');
+  }
+
+  if (!buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
+    throw new Error('Invalid PNG signature.');
+  }
+
+  const chunks = [];
+  let offset = PNG_SIGNATURE.length;
+  while (offset < buffer.length) {
+    if (offset + 8 > buffer.length) {
+      throw new Error('Unexpected end of PNG buffer.');
+    }
+    const length = readUInt32BE(buffer, offset);
+    offset += 4;
+    const type = buffer.subarray(offset, offset + 4).toString('ascii');
+    offset += 4;
+    if (offset + length + 4 > buffer.length) {
+      throw new Error('PNG chunk length exceeds buffer size.');
+    }
+    const data = buffer.subarray(offset, offset + length);
+    offset += length;
+    const expectedCrc = readUInt32BE(buffer, offset);
+    offset += 4;
+
+    const crcBuffer = Buffer.concat([Buffer.from(type, 'ascii'), Buffer.from(data)]);
+    const actualCrc = crc32(crcBuffer);
+    if (actualCrc !== expectedCrc) {
+      throw new Error(`CRC mismatch in PNG chunk ${type}.`);
+    }
+
+    chunks.push({ type, data: Buffer.from(data) });
+    if (type === 'IEND') break;
+  }
+
+  return chunks;
+}
+
+function unfilter(scanlines, width, height) {
+  const stride = width * BYTES_PER_PIXEL;
+  const output = Buffer.alloc(height * stride);
+
+  for (let y = 0; y < height; y++) {
+    const filterType = scanlines[y * (stride + 1)];
+    const inOffset = y * (stride + 1) + 1;
+    const outOffset = y * stride;
+    const prevOffset = y > 0 ? (y - 1) * stride : -1;
+
+    for (let x = 0; x < stride; x++) {
+      const raw = scanlines[inOffset + x];
+      const left = x >= BYTES_PER_PIXEL ? output[outOffset + x - BYTES_PER_PIXEL] : 0;
+      const up = y > 0 ? output[prevOffset + x] : 0;
+      const upLeft = y > 0 && x >= BYTES_PER_PIXEL ? output[prevOffset + x - BYTES_PER_PIXEL] : 0;
+
+      let recon;
+      switch (filterType) {
+        case 0:
+          recon = raw;
+          break;
+        case 1: // Sub
+          recon = (raw + left) & 0xff;
+          break;
+        case 2: // Up
+          recon = (raw + up) & 0xff;
+          break;
+        case 3: // Average
+          recon = (raw + Math.floor((left + up) / 2)) & 0xff;
+          break;
+        case 4: // Paeth
+          recon = (raw + paethPredictor(left, up, upLeft)) & 0xff;
+          break;
+        default:
+          throw new Error(`Unsupported PNG filter type: ${filterType}`);
+      }
+
+      output[outOffset + x] = recon;
+    }
+  }
+
+  return output;
+}
+
+function paethPredictor(a, b, c) {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) return a;
+  if (pb <= pc) return b;
+  return c;
+}
+
+function filterNone(data, width, height) {
+  const stride = width * BYTES_PER_PIXEL;
+  const output = Buffer.alloc(height * (stride + 1));
+  for (let y = 0; y < height; y++) {
+    const inOffset = y * stride;
+    const outOffset = y * (stride + 1);
+    output[outOffset] = 0;
+    data.copy(output, outOffset + 1, inOffset, inOffset + stride);
+  }
+  return output;
+}
+
+function createChunk(type, data) {
+  const length = writeUInt32BE(data.length);
+  const typeBuf = Buffer.from(type, 'ascii');
+  const crcBuf = writeUInt32BE(crc32(Buffer.concat([typeBuf, data])));
+  return Buffer.concat([length, typeBuf, data, crcBuf]);
+}
+
+export function decodePng(buffer) {
+  const chunks = parseChunks(Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer));
+
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  const idatParts = [];
+
+  for (const { type, data } of chunks) {
+    if (type === 'IHDR') {
+      width = readUInt32BE(data, 0);
+      height = readUInt32BE(data, 4);
+      bitDepth = data[8];
+      colorType = data[9];
+    } else if (type === 'IDAT') {
+      idatParts.push(data);
+    }
+  }
+
+  if (!width || !height) {
+    throw new Error('PNG missing IHDR chunk.');
+  }
+
+  if (bitDepth !== BIT_DEPTH_8 || colorType !== COLOR_TYPE_RGBA) {
+    throw new Error('Only 8-bit RGBA PNG images are supported.');
+  }
+
+  const compressed = Buffer.concat(idatParts);
+  const decompressed = inflateSync(compressed);
+  const expectedLength = height * (width * BYTES_PER_PIXEL + 1);
+  if (decompressed.length !== expectedLength) {
+    throw new Error('Unexpected decompressed PNG data length.');
+  }
+
+  const data = unfilter(decompressed, width, height);
+  return { width, height, data };
+}
+
+export function encodePng({ width, height, data }) {
+  if (!width || !height) {
+    throw new Error('PNG width and height must be provided.');
+  }
+  if (!data || data.length !== width * height * BYTES_PER_PIXEL) {
+    throw new Error('PNG data length does not match width and height.');
+  }
+
+  const filtered = filterNone(Buffer.isBuffer(data) ? data : Buffer.from(data), width, height);
+  const compressed = deflateSync(filtered);
+
+  const ihdrData = Buffer.alloc(13);
+  writeUInt32BE(width).copy(ihdrData, 0);
+  writeUInt32BE(height).copy(ihdrData, 4);
+  ihdrData[8] = BIT_DEPTH_8;
+  ihdrData[9] = COLOR_TYPE_RGBA;
+  ihdrData[10] = 0; // compression method
+  ihdrData[11] = 0; // filter method
+  ihdrData[12] = 0; // interlace method
+
+  const chunks = [
+    PNG_SIGNATURE,
+    createChunk('IHDR', ihdrData),
+    createChunk('IDAT', compressed),
+    createChunk('IEND', Buffer.alloc(0))
+  ];
+
+  return Buffer.concat(chunks);
+}
+
+export default {
+  decodePng,
+  encodePng
+};

--- a/test/png-composer.test.js
+++ b/test/png-composer.test.js
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import { PNG } from 'pngjs';
+
+function createPngBuffer(width, height, fill) {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (width * y + x) << 2;
+      const color = fill({ x, y, idx });
+      png.data[idx] = color[0];
+      png.data[idx + 1] = color[1];
+      png.data[idx + 2] = color[2];
+      png.data[idx + 3] = color[3];
+    }
+  }
+  return PNG.sync.write(png);
+}
+
+test('built-in PNG composer blends overlays when pngjs is unavailable', async (t) => {
+  process.env.FORCE_SIMPLE_PNG_COMPOSER = '1';
+  const modulePath = `../lib/pngComposer.js?force=${Date.now()}`;
+  const pngComposerModule = await import(modulePath);
+  t.after(() => {
+    delete process.env.FORCE_SIMPLE_PNG_COMPOSER;
+  });
+
+  assert.ok(
+    pngComposerModule.isPngComposerAvailable(),
+    'Expected built-in PNG composer to be available'
+  );
+  assert.strictEqual(
+    pngComposerModule.getPngComposerImplementation(),
+    'builtin-simple'
+  );
+
+  const baseBuffer = createPngBuffer(2, 2, () => [0, 0, 0, 0]);
+  const overlayBuffer = createPngBuffer(2, 2, ({ x, y }) =>
+    x === 1 && y === 0 ? [255, 0, 0, 128] : [0, 0, 255, 255]
+  );
+
+  const composed = pngComposerModule.composePngBuffers(baseBuffer, [overlayBuffer]);
+  const result = PNG.sync.read(composed);
+
+  const topRight = result.data.subarray((2 * 0 + 1) * 4, (2 * 0 + 1) * 4 + 4);
+  assert.ok(topRight[3] > 0, 'alpha channel should be non-zero');
+  assert.ok(topRight[0] > topRight[2], 'red channel should dominate after blend');
+
+  const bottomLeft = result.data.subarray((2 * 1 + 0) * 4, (2 * 1 + 0) * 4 + 4);
+  assert.strictEqual(bottomLeft[2], 255);
+  assert.strictEqual(bottomLeft[3], 255);
+});


### PR DESCRIPTION
## Summary
- add a pure JavaScript PNG encoder/decoder and expose it as a fallback composer
- update inventory image setup to report which composer implementation is active
- cover the new fallback with automated tests that blend overlay pixels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1a9e63f3c832aab841d762a3c2158