### PR TITLE
Ensure new player persistence and improve keep-alive handling

### DIFF
--- a/test/save-data.test.js
+++ b/test/save-data.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 
 process.env.NODE_ENV = 'test';
@@ -17,40 +18,106 @@ async function removeIfExists(filePath) {
   }
 }
 
-test('persists player infection through save/load cycle', async (t) => {
+async function waitForPlayerPersist(filePath, playerId, attempts = 40, delayMs = 25) {
+  let lastData = null;
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const data = JSON.parse(raw);
+      lastData = data;
+      if (data.players && data.players[playerId]) {
+        return data;
+      }
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+    await delay(delayMs);
+  }
+
+  const error = new Error(`Player ${playerId} was not persisted to ${filePath}`);
+  if (lastData) {
+    error.lastData = lastData;
+  }
+  throw error;
+}
+
+async function withIsolatedBot(label, run) {
+  const suffix = `${label}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const tempStateFile = path.join(__dirname, `${suffix}.json`);
+  const tempBackupFile = path.join(__dirname, `${suffix}-backup.json`);
+
+  await Promise.all([
+    removeIfExists(tempStateFile),
+    removeIfExists(tempBackupFile)
+  ]);
+
   process.env.NODE_ENV = 'test';
-  const tempStateFile = path.join(__dirname, 'temp-state.json');
-  const tempBackupFile = path.join(__dirname, 'temp-state-backup.json');
   process.env.DATA_FILE = tempStateFile;
   process.env.DATA_BACKUP_FILE = tempBackupFile;
 
-  await Promise.all([
-    removeIfExists(tempStateFile),
-    removeIfExists(tempBackupFile)
-  ]);
+  const module = await import(`../index.js?${suffix}`);
 
-  const module = await import('../index.js');
-  const { loadData, saveData, ensurePlayer } = module;
-  const getPlayers = () => module.players;
+  try {
+    await module.loadData();
+    await run({ module, tempStateFile, tempBackupFile });
+  } finally {
+    delete process.env.DATA_FILE;
+    delete process.env.DATA_BACKUP_FILE;
 
-  await loadData();
-  const player = ensurePlayer({ id: 123456, first_name: 'Tester', username: 'tester' });
-  player.infection = 77;
-  await saveData();
+    await Promise.all([
+      removeIfExists(tempStateFile),
+      removeIfExists(tempBackupFile)
+    ]);
+  }
+}
 
-  player.infection = 0;
+test('persists player infection through save/load cycle', async () => {
+  await withIsolatedBot('infection', async ({ module, tempStateFile }) => {
+    const { saveData, ensurePlayer } = module;
 
-  await loadData();
-  assert.equal(getPlayers()['123456'].infection, 77);
+    const player = ensurePlayer({ id: 123456, first_name: 'Tester', username: 'tester' });
+    player.infection = 77;
+    await saveData();
 
-  const persisted = JSON.parse(await fs.readFile(tempStateFile, 'utf-8'));
-  assert.equal(persisted.players['123456'].infection, 77);
+    player.infection = 0;
 
-  await Promise.all([
-    removeIfExists(tempStateFile),
-    removeIfExists(tempBackupFile)
-  ]);
+    await module.loadData();
+    assert.equal(module.players['123456'].infection, 77);
 
-  delete process.env.DATA_FILE;
-  delete process.env.DATA_BACKUP_FILE;
+    const persisted = await waitForPlayerPersist(tempStateFile, '123456');
+    assert.equal(persisted.players['123456'].infection, 77);
+  });
+});
+
+test('newly created players persist to both primary and backup files', async () => {
+  await withIsolatedBot('new-player', async ({ module, tempStateFile, tempBackupFile }) => {
+    const playerId = '789654';
+    const player = module.ensurePlayer({ id: Number(playerId), first_name: 'Newbie', username: 'newbie' });
+
+    const persistedPrimary = await waitForPlayerPersist(tempStateFile, playerId);
+    assert.ok(persistedPrimary.players[playerId], 'player should exist in main data file');
+    assert.equal(persistedPrimary.players[playerId].hp, 100);
+    assert.deepEqual(persistedPrimary.players[playerId].inventory, {
+      armor: null,
+      helmet: null,
+      weapon: null,
+      mutation: null,
+      extra: null,
+      sign: null
+    });
+
+    const persistedBackup = await waitForPlayerPersist(tempBackupFile, playerId);
+    assert.ok(persistedBackup.players[playerId], 'player should exist in backup file');
+    assert.deepEqual(persistedBackup.players[playerId].inventory, persistedPrimary.players[playerId].inventory);
+
+    // Mutate in-memory state and ensure a reload restores persisted values.
+    player.hp = 5;
+    player.inventory.weapon = { name: 'Test Blade' };
+
+    await module.loadData();
+    assert.equal(module.players[playerId].hp, 100);
+    assert.equal(module.players[playerId].inventory.weapon, null);
+  });
 });


### PR DESCRIPTION
## Summary
- add isolated state helpers in save-data tests and cover persistence of newly created players
- require explicit keep-alive URL configuration, add timeout handling, and skip autosave timers during tests to reduce noise

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1be6a9cf8832aa0123b8b42e5253a