### PR TITLE
Ensure bot state persists to PostgreSQL

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -21,8 +21,17 @@ const noopPool = {
 
 let pool = noopPool;
 
+function hasExplicitPostgresConfig() {
+  if (process.env.DATABASE_URL) return true;
+
+  const pgKeys = ['PGHOST', 'PGUSER', 'PGDATABASE'];
+  const hasRequired = pgKeys.every((key) => process.env[key]);
+  const hasAny = pgKeys.some((key) => process.env[key]);
+  return hasRequired && hasAny;
+}
+
 if (process.env.NODE_ENV !== 'test') {
-  const hasPostgresConfig = Boolean(process.env.DATABASE_URL);
+  const hasPostgresConfig = hasExplicitPostgresConfig();
   const requiredMysqlEnv = ['DB_HOST', 'DB_USER', 'DB_NAME'];
   const hasAllMysqlEnv = requiredMysqlEnv.every((key) => process.env[key]);
   const hasAnyMysqlEnv = requiredMysqlEnv.some((key) => process.env[key]);
@@ -31,9 +40,22 @@ if (process.env.NODE_ENV !== 'test') {
     const { module: pgModule, error } = await optionalImport('pg');
     if (pgModule?.Pool) {
       const { Pool } = pgModule;
+      const baseConfig = process.env.DATABASE_URL
+        ? { connectionString: process.env.DATABASE_URL }
+        : {
+            host: process.env.PGHOST,
+            port: process.env.PGPORT ? Number.parseInt(process.env.PGPORT, 10) : undefined,
+            user: process.env.PGUSER,
+            password: process.env.PGPASSWORD,
+            database: process.env.PGDATABASE
+          };
+      const sslEnabled =
+        process.env.DB_SSL === 'true' ||
+        process.env.PGSSL === 'true' ||
+        (process.env.PGSSLMODE && process.env.PGSSLMODE !== 'disable');
       const pgPool = new Pool({
-        connectionString: process.env.DATABASE_URL,
-        ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : undefined
+        ...baseConfig,
+        ssl: sslEnabled ? { rejectUnauthorized: false } : undefined
       });
       pool = {
         dialect: 'postgres',
@@ -105,6 +127,36 @@ if (process.env.NODE_ENV !== 'test') {
     console.warn(
       'Переменные окружения MySQL указаны не полностью; падение в режим памяти.'
     );
+  }
+}
+
+export async function initializeDatabase() {
+  if (!pool || pool.dialect === 'memory') {
+    return false;
+  }
+
+  try {
+    if (pool.dialect === 'postgres') {
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS bot_state (
+          id INTEGER PRIMARY KEY,
+          state JSONB NOT NULL,
+          updated_at TIMESTAMPTZ DEFAULT NOW()
+        )
+      `);
+    } else if (pool.dialect === 'mysql') {
+      await pool.execute(`
+        CREATE TABLE IF NOT EXISTS bot_state (
+          id INT PRIMARY KEY,
+          state JSON NOT NULL,
+          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        )
+      `);
+    }
+    return true;
+  } catch (err) {
+    console.error('Не удалось инициализировать базу данных:', err);
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary
- initialize the bot_state table automatically for PostgreSQL/MySQL at startup
- improve PostgreSQL connection detection and SSL handling from Render env vars
- generalize database logging and ensure JSON is stored with correct types

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1e91efae4832a8cf450112b34cdd3