### PR TITLE
Add chat shortcut to main menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -1854,7 +1854,8 @@ function mainMenuKeyboard() {
       [{ text: "🏆 Таблица лидеров", callback_data: "leaderboard" }],
       [{ text: "⚔️ PvP", callback_data: "pvp_menu" }],
       [{ text: "🏰 Кланы", callback_data: "clans_menu" }],
-      [{ text: "📢 Канал", url: "https://t.me/crimecorebotgame" }]
+      [{ text: "📢 Канал", url: "https://t.me/crimecorebotgame" }],
+      [{ text: "💬 Чат", url: "https://t.me/+uHiRhUs7EH0xZDVi" }]
     ]
   };
 }


### PR DESCRIPTION
## Summary
- add a new inline button to the main menu that links players to the community chat

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ca43a8848333aa252bb3f775aaf5