### PR TITLE
Add rarity tiers to loot drops

### DIFF
--- a/lib/items.js
+++ b/lib/items.js
@@ -36,7 +36,53 @@ const ITEM_IMAGE_MAP = loadItemImageMap();
 
 export const getItemImageMap = () => ({ ...ITEM_IMAGE_MAP });
 
-export const armorItems = [
+export const ITEM_RARITY = {
+  VERY_RARE: { key: 'very_rare', label: 'крайне редкое' },
+  RARE: { key: 'rare', label: 'редкое' },
+  COMMON: { key: 'common', label: 'обычная редкость' }
+};
+
+function assignRarity(items, kind) {
+  const enriched = items.map((item) => ({
+    ...item,
+    ...(kind ? { kind } : {})
+  }));
+
+  if (enriched.length === 0) {
+    return enriched;
+  }
+
+  const byChanceAsc = enriched
+    .map((item, index) => ({
+      index,
+      chance: Number.isFinite(item.chance) ? item.chance : Number.POSITIVE_INFINITY
+    }))
+    .sort((a, b) => a.chance - b.chance);
+
+  const total = byChanceAsc.length;
+  const veryRareLimit = Math.max(1, Math.ceil(total / 3));
+  const rareLimit = Math.max(veryRareLimit, Math.ceil((total * 2) / 3));
+
+  for (let i = 0; i < byChanceAsc.length; i += 1) {
+    const { index } = byChanceAsc[i];
+    const rarity =
+      i < veryRareLimit
+        ? ITEM_RARITY.VERY_RARE
+        : i < rareLimit
+          ? ITEM_RARITY.RARE
+          : ITEM_RARITY.COMMON;
+
+    enriched[index] = {
+      ...enriched[index],
+      rarity: rarity.label,
+      rarityKey: rarity.key
+    };
+  }
+
+  return enriched;
+}
+
+const armorItemsBase = [
   { name: "Бронежилет химзащита", hp: 20, chance: 25 },
   { name: "Броня бинты", hp: 30, chance: 22 },
   { name: "Бронежилет из жертв", hp: 40, chance: 20 },
@@ -52,7 +98,7 @@ export const armorItems = [
   { name: "Броня скелет", hp: 1400, chance: 0.3 }
 ];
 
-export const weaponItems = [
+const weaponItemsBase = [
   { name: "Бита", dmg: 10, chance: 15 },
   { name: "Перочинный нож", dmg: 15, chance: 13 },
   { name: "Кухонный нож", dmg: 15, chance: 13 },
@@ -80,7 +126,7 @@ export const weaponItems = [
   { name: "Подопытный", dmg: 450, chance: 0.1 }
 ];
 
-export const helmetItems = [
+const helmetItemsBase = [
   { name: "Пакет", block: 2, chance: 20 },
   { name: "Шлем шапка", block: 3, chance: 19 },
   { name: "Шлем бинты", block: 3, chance: 19 },
@@ -99,7 +145,7 @@ export const helmetItems = [
   { name: "Шлем CRIMECORE", block: 40, chance: 2 }
 ];
 
-export const mutationItems = [
+const mutationItemsBase = [
   { name: "Зубной", crit: 0.10, chance: 25 },
   { name: "Кровоточащий", crit: 0.15, chance: 20 },
   { name: "Порезанный", crit: 0.15, chance: 20 },
@@ -112,14 +158,20 @@ export const mutationItems = [
   { name: "Бог", crit: 0.50, chance: 2 }
 ];
 
-export const extraItems = [
+const extraItemsBase = [
   { name: "Фотоаппарат со вспышкой", effect: "stun2", chance: 20, turns: 2 },
   { name: "Слеповая граната", effect: "stun2", chance: 20, turns: 2 },
   { name: "Петарда", effect: "damage50", chance: 20 },
   { name: "Граната", effect: "damage100", chance: 15 },
   { name: "Адреналин", effect: "halfDamage1", chance: 12, turns: 1 },
-  { name: "Газовый балон", effect: "doubleDamage1", chance: 6, turns: 1 },
+  { name: "Газовый балон", effect: "doubleDamage1", chance: 6, turns: 1 }
 ];
+
+export const armorItems = assignRarity(armorItemsBase, 'armor');
+export const weaponItems = assignRarity(weaponItemsBase, 'weapon');
+export const helmetItems = assignRarity(helmetItemsBase, 'helmet');
+export const mutationItems = assignRarity(mutationItemsBase, 'mutation');
+export const extraItems = assignRarity(extraItemsBase, 'extra');
 
 export const signItems = [
   { name: "Знак внимание", kind: "sign", vampirism: 0.10, caseEligible: true },


### PR DESCRIPTION
## Summary
- categorize lootable equipment items into three rarity tiers derived from drop chance
- surface the item's rarity in reward and drop notifications so players see how rare the item is

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddc78bf6708333aa60669c92a249c9