### PR TITLE
Добавить раздел ресурсов и унифицировать сообщения меню

### DIFF
--- a/index.js
+++ b/index.js
@@ -1068,6 +1068,101 @@ function restartBot() {
     }, 3000);
 }
 
+function formatPlayerDisplayName(player) {
+  if (!player) return "—";
+  if (player.username) return `@${escMd(player.username)}`;
+  if (player.name) return escMd(player.name);
+  if (player.id) return escMd(player.id);
+  return "—";
+}
+
+function buildPlayerOverview(player) {
+  if (!player) return "";
+  ensurePvpRatingFields(player);
+  const clanName =
+    player.clanId && clans[String(player.clanId)]
+      ? escMd(clans[String(player.clanId)].name)
+      : "—";
+  const hpCurrent = Number.isFinite(player.hp) ? player.hp : 0;
+  const hpMax = Number.isFinite(player.maxHp) ? player.maxHp : hpCurrent;
+  const infection = Number.isFinite(player.infection) ? player.infection : 0;
+  const wins = Number.isFinite(player.pvpWins) ? player.pvpWins : 0;
+  const losses = Number.isFinite(player.pvpLosses) ? player.pvpLosses : 0;
+  const rating = Number.isFinite(player.pvpRating) ? player.pvpRating : 0;
+  const ratingBest = Number.isFinite(player.pvpRatingBest) ? player.pvpRatingBest : rating;
+  const survivalDays = Number.isFinite(player.survivalDays) ? player.survivalDays : 0;
+
+  return [
+    `👤 Игрок: ${formatPlayerDisplayName(player)}`,
+    `❤️ Здоровье: ${hpCurrent}/${hpMax}`,
+    `☣️ Заражение: ${infection}`,
+    `🏆 PvP: ${wins} побед / ${losses} поражений`,
+    `🥇 Рейтинг PvP: ${rating} (рекорд: ${ratingBest})`,
+    `📅 Дней выживания: ${survivalDays}`,
+    `🏰 Клан: ${clanName}`
+  ].join("\n");
+}
+
+function buildMainMenuText(player) {
+  const overview = buildPlayerOverview(player);
+  return overview
+    ? `${overview}\n\n🏠 Главное меню\nВыбери действие ниже.`
+    : "🏠 Главное меню\nВыбери действие ниже.";
+}
+
+function buildStartMessage(player) {
+  const displayName = formatPlayerDisplayName(player);
+  const overview = buildPlayerOverview(player);
+  const intro = displayName !== "—" ? `Привет, ${displayName}!` : "Привет!";
+  return overview
+    ? `${intro}\n\n${overview}\n\nИспользуй кнопки ниже, чтобы продолжить игру.`
+    : `${intro}\nИспользуй кнопки ниже, чтобы продолжить игру.`;
+}
+
+function formatItemLine(label, item, detailBuilder) {
+  if (!item) return `${label}: —`;
+  const name = escMd(item.name || "—");
+  let detailText = "";
+  if (typeof detailBuilder === "function") {
+    const detail = detailBuilder(item);
+    if (detail) {
+      detailText = ` (${escMd(detail)})`;
+    }
+  }
+  return `${label}: ${name}${detailText}`;
+}
+
+function buildInventoryText(player) {
+  if (!player) return "🎒 Инвентарь пуст.";
+  const inv = player.inventory || {};
+  const overview = buildPlayerOverview(player);
+  const lines = [
+    "🎒 Инвентарь",
+    "",
+    overview,
+    "",
+    formatItemLine("🪖 Шлем", inv.helmet, (item) =>
+      typeof item.block !== "undefined" ? `блок ${item.block}%` : null
+    ),
+    formatItemLine("🛡 Броня", inv.armor, (item) =>
+      typeof item.hp !== "undefined" ? `HP +${item.hp}` : null
+    ),
+    formatItemLine("🔫 Оружие", inv.weapon, (item) =>
+      typeof item.dmg !== "undefined" ? `урон +${item.dmg}` : null
+    ),
+    formatItemLine("🧬 Мутация", inv.mutation, (item) => {
+      if (typeof item.crit !== "undefined") {
+        const critPercent = item.crit <= 1 ? Math.round(item.crit * 100) : item.crit;
+        return `crit ${critPercent}%`;
+      }
+      return null;
+    }),
+    formatItemLine("📦 Доп", inv.extra, (item) => item.effect || null),
+    formatItemLine("⚠️ Знак", inv.sign, (item) => describeSignEffect(item))
+  ];
+  return lines.join("\n");
+}
+
 function mainMenuKeyboard() {
   return {
     inline_keyboard: [
@@ -1076,7 +1171,8 @@ function mainMenuKeyboard() {
       [{ text: "🎒 Инвентарь", callback_data: "inventory" }],
       [{ text: "🏆 Таблица лидеров", callback_data: "leaderboard" }],
       [{ text: "⚔️ PvP", callback_data: "pvp_menu" }],
-      [{ text: "🏰 Кланы", callback_data: "clans_menu" }]
+      [{ text: "🏰 Кланы", callback_data: "clans_menu" }],
+      [{ text: "📚 Ресурсы", callback_data: "resources" }]
     ]
   };
 }
@@ -1085,7 +1181,9 @@ function lootMenuKeyboard() {
   return {
     inline_keyboard: [
       [{ text: "🆓 Бесплатный подарок", callback_data: "free_gift" }],
-      [{ text: "➕ Бесплатный подарок", callback_data: "invite_friend" }],
+      [{ text: "🧟‍♂️ Притащить тело (бесплатно)", callback_data: "invite_friend" }],
+      [{ text: "Знаки (5000 очков заражения)", callback_data: "sign_case" }],
+      [{ text: "☣️ Зараженное тело (3000 очков заражения)", callback_data: "infection_case" }],
       [{ text: "⬅️ Назад", callback_data: "play" }]
     ]
   };
@@ -1098,6 +1196,16 @@ function clansMenuKeyboard() {
       [{ text: "Топ кланов", callback_data: "clans_top" }],
       [{ text: "Клановая битва", callback_data: "clans_battle_info" }],
       [{ text: "⚔️ Захват чата", callback_data: "clans_assault_info" }],
+      [{ text: "⬅️ Назад", callback_data: "play" }]
+    ]
+  };
+}
+
+function resourcesKeyboard() {
+  return {
+    inline_keyboard: [
+      [{ text: "📢 Канал", url: "https://t.me/crimecorebotgame" }],
+      [{ text: "💬 Чат", url: "https://t.me/+uHiRhUs7EH0xZDVi" }],
       [{ text: "⬅️ Назад", callback_data: "play" }]
     ]
   };
@@ -2219,21 +2327,6 @@ async function editOrSend(chatId, messageId, text, options = {}) {
   }
 }
 
-function mainMenuKeyboard() {
-  return {
-    inline_keyboard: [
-      [{ text: "🩸 Выйти на охоту", callback_data: "hunt" }],
-      [{ text: "🎰 Лутать тело", callback_data: "loot_menu" }],
-      [{ text: "🎒 Инвентарь", callback_data: "inventory" }],
-      [{ text: "🏆 Таблица лидеров", callback_data: "leaderboard" }],
-      [{ text: "⚔️ PvP", callback_data: "pvp_menu" }],
-      [{ text: "🏰 Кланы", callback_data: "clans_menu" }],
-      [{ text: "📢 Канал", url: "https://t.me/crimecorebotgame" }],
-      [{ text: "💬 Чат", url: "https://t.me/+uHiRhUs7EH0xZDVi" }]
-    ]
-  };
-}
-
 function pvpMenuKeyboard() {
   return {
     inline_keyboard: [
@@ -2241,18 +2334,6 @@ function pvpMenuKeyboard() {
       [{ text: "🤖 Поиск противника", callback_data: "pvp_find" }],
       [{ text: "🥇 Рейтинговый PVP", callback_data: "pvp_ranked" }],
       [{ text: "🏆 Таблица лидеров PVP", callback_data: "pvp_leaderboard" }],
-      [{ text: "⬅️ Назад", callback_data: "play" }]
-    ]
-  };
-}
-
-function lootMenuKeyboard() {
-  return {
-    inline_keyboard: [
-      [{ text: "🆓 Бесплатный подарок", callback_data: "free_gift" }],
-      [{ text: "🧟‍♂️ Притащить тело (бесплатно)", callback_data: "invite_friend" }],
-      [{ text: "Знаки (5000 очков заражения)", callback_data: "sign_case" }],
-      [{ text: "☣️ Зараженное тело (3000 очков заражения)", callback_data: "infection_case" }],
       [{ text: "⬅️ Назад", callback_data: "play" }]
     ]
   };
@@ -3617,8 +3698,16 @@ bot.on("callback_query", async (q) => {
     console.error("Group gating error:", e);
   }
   // === /Ограничение кнопок ===
-    let player = ensurePlayer(user);
-// --- Обработчики для кнопок главного меню: PvP и Кланы ---
+  let player = ensurePlayer(user);
+  if (dataCb === "resources") {
+    const text = "📚 Полезные ресурсы\nВыбери, куда перейти:";
+    await editOrSend(chatId, messageId, text, {
+      reply_markup: resourcesKeyboard(),
+      parse_mode: null
+    });
+    return;
+  }
+  // --- Обработчики для кнопок главного меню: PvP и Кланы ---
 if (dataCb === "pvp_request" || dataCb === "pvp_menu") {
   await editOrSend(chatId, messageId, "⚔️ Выберите режим PvP:", { reply_markup: pvpMenuKeyboard() });
   return;
@@ -3845,7 +3934,11 @@ if (dataCb === "play") {
     }
 
     // Отправляем новое меню и сохраняем его message_id
-    const sent = await bot.sendMessage(chatId, "🏠 Главное меню", { reply_markup: mainMenuKeyboard() });
+    const menuText = buildMainMenuText(player);
+    const sent = await bot.sendMessage(chatId, menuText, {
+      reply_markup: mainMenuKeyboard(),
+      parse_mode: "Markdown"
+    });
     player.lastMainMenuMsgId = sent.message_id;
     saveData();
     return;
@@ -4507,22 +4600,7 @@ if (dataCb === "attack") {
     const chatId = q.message.chat.id;
     const player = ensurePlayer(q.from);
     ensurePvpRatingFields(player);
-    let clanName = player.clanId && clans[player.clanId] ? clans[player.clanId].name : "—";
-    let inv = player.inventory || {};
-    let text = `🎒 Инвентарь:
-Клан: ${clanName}
-🪖 Шлем: ${inv.helmet?.name || "—"} (${inv.helmet?.block !== undefined ? `блок ${inv.helmet.block}%` : "—"})
-🛡 Броня: ${inv.armor?.name || "—"} (${inv.armor?.hp !== undefined ? `HP +${inv.armor.hp}` : "—"})
-🔫 Оружие: ${inv.weapon?.name || "—"} (${inv.weapon?.dmg !== undefined ? `+${inv.weapon.dmg} урона` : "—"})
-🧬 Мутация: ${inv.mutation?.name || "—"} (${inv.mutation?.crit !== undefined ? `crit ${inv.mutation.crit}%` : "—"})
-📦 Доп: ${inv.extra?.name || "—"} (${inv.extra?.effect || "—"})
-⚠️ Знак: ${inv.sign?.name || "—"} (${describeSignEffect(inv.sign)})
-
-❤️ HP: ${player.hp}/${player.maxHp}
-☣️ Заражение: ${player.infection || 0}
-🏆 PvP: ${player.pvpWins || 0} побед / ${player.pvpLosses || 0} поражений
-🥇 Рейтинг PvP: ${player.pvpRating} (рекорд: ${player.pvpRatingBest})`;
-
+    const text = buildInventoryText(player);
     const img = await generateInventoryImage(player);
     const kb = { inline_keyboard: [[{ text: "⬅️ Назад", callback_data: "play" }]] };
     if (img) {
@@ -4681,7 +4759,8 @@ bot.onText(/\/play/, (msg) => {
   const player = ensurePlayer(msg.from);
   if (!player) return bot.sendMessage(msg.chat.id, "Ошибка регистрации. Попробуйте /start.");
   applyArmorHelmetBonuses(player);
-  editOrSend(msg.chat.id, null, `Выберите действие:`, { reply_markup: mainMenuKeyboard() });
+  const menuText = buildMainMenuText(player);
+  editOrSend(msg.chat.id, null, menuText, { reply_markup: mainMenuKeyboard() });
 });
 
 // /report
@@ -4795,17 +4874,9 @@ bot.onText(/\/start(?:\s+(.+))?/, async (msg, match) => {
   }
 
   applyArmorHelmetBonuses(player);
-  const inv = player.inventory;
-  const armorLine = inv.armor ? `${inv.armor.name} (+${inv.armor.hp} HP)` : "—";
-  const weaponLine = inv.weapon ? `${inv.weapon.name} (+${inv.weapon.dmg} dmg)` : "—";
-  const helmetLine = inv.helmet ? `${inv.helmet.name} (блок ${inv.helmet.block}%)` : "—";
-  const mutLine = inv.mutation ? `${inv.mutation.name} (crit ${Math.round((inv.mutation.crit || 0) * 100)}%)` : "—";
+  const startText = buildStartMessage(player);
   await bot
-    .sendMessage(
-      msg.chat.id,
-      `Привет, @${player.username}!\n❤️ HP: ${player.hp}/${player.maxHp}\n🛡 Броня: ${armorLine}\n🔫 Оружие: ${weaponLine}\n🪖 Шлем: ${helmetLine}\n🧬 Мутация: ${mutLine}`,
-      { reply_markup: mainMenuKeyboard() }
-    )
+    .sendMessage(msg.chat.id, startText, { reply_markup: mainMenuKeyboard(), parse_mode: "Markdown" })
     .catch(() => {});
 });
 
@@ -5238,22 +5309,7 @@ bot.onText(/\/inventory/, async (msg) => {
   const player = ensurePlayer(msg.from);
   if (!player) return bot.sendMessage(chatId, "Ошибка: нет профиля");
   ensurePvpRatingFields(player);
-
-  let clanName = player.clanId && clans[player.clanId] ? clans[player.clanId].name : "—";
-  let inv = player.inventory || {};
-  let text = `🎒 Инвентарь:
-Клан: ${clanName}
-🪖 Шлем: ${inv.helmet?.name || "—"} (${inv.helmet?.block || "—"})
-🛡 Броня: ${inv.armor?.name || "—"} (${inv.armor?.hp || "—"})
-🔫 Оружие: ${inv.weapon?.name || "—"} (${inv.weapon?.dmg || "—"})
-🧬 Мутация: ${inv.mutation?.name || "—"} (${inv.mutation?.crit || "—"})
-📦 Доп: ${inv.extra?.name || "—"} (${inv.extra?.effect || "—"})
-
-❤️ HP: ${player.hp}/${player.maxHp}
-☣️ Заражение: ${player.infection || 0}
-🏆 PvP: ${player.pvpWins || 0} побед / ${player.pvpLosses || 0} поражений
-🥇 Рейтинг PvP: ${player.pvpRating} (рекорд: ${player.pvpRatingBest})`;
-
+  const text = buildInventoryText(player);
   const img = await generateInventoryImage(player);
   const kb = { inline_keyboard: [[{ text: "⬅️ Назад", callback_data: "play" }]] };
   if (img) {

--- a/test/buttons.test.js
+++ b/test/buttons.test.js
@@ -15,10 +15,16 @@ test('main menu contains all expected buttons', () => {
   assert.ok(callbacks.includes('clans_menu'));
 });
 
-test('loot menu contains free gift and back buttons', () => {
+test('loot menu contains expected reward options', () => {
   const keyboard = lootMenuKeyboard();
   const callbacks = keyboard.inline_keyboard.flat().map(btn => btn.callback_data);
-  assert.deepStrictEqual(callbacks, ['free_gift', 'invite_friend', 'play']);
+  assert.deepStrictEqual(callbacks, [
+    'free_gift',
+    'invite_friend',
+    'sign_case',
+    'infection_case',
+    'play'
+  ]);
 });
 
 test('clan menu has expected sections', () => {


### PR DESCRIPTION
## Summary
- добавлен общий хелпер для формирования статуса игрока и единообразные тексты для /start, главного меню и инвентаря
- обновлён главный экран: вместо отдельных кнопок канала и чата добавлен раздел «Ресурсы» с вложенным меню
- расширены юнит-тесты кнопок, чтобы отражать новые элементы меню

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de336108e883338c382e9dcbba7790