### PR TITLE
Fix escMd ReferenceError by hoisting markdown escape helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1068,6 +1068,29 @@ function restartBot() {
     }, 3000);
 }
 
+function escMd(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/\_/g, '\\_')
+    .replace(/\*/g, '\\*')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/\~/g, '\\~')
+    .replace(/\`/g, '\\`')
+    .replace(/\>/g, '\\>')
+    .replace(/\#/g, '\\#')
+    .replace(/\+/g, '\\+')
+    .replace(/\-/g, '\\-')
+    .replace(/\=/g, '\\=')
+    .replace(/\|/g, '\\|')
+    .replace(/\{/g, '\\{')
+    .replace(/\}/g, '\\}')
+    .replace(/\./g, '\\.')
+    .replace(/\!/g, '\\!');
+}
+
 function formatPlayerDisplayName(player) {
   if (!player) return "—";
   if (player.username) return `@${escMd(player.username)}`;
@@ -1289,29 +1312,6 @@ async function startBot() {
     console.error("patch editMessageText failed:", e.message);
   }
   // === /Патч безопасного редактирования сообщений ===
-
-function escMd(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/\_/g, '\\_')
-    .replace(/\*/g, '\\*')
-    .replace(/\[/g, '\\[')
-    .replace(/\]/g, '\\]')
-    .replace(/\(/g, '\\(')
-    .replace(/\)/g, '\\)')
-    .replace(/\~/g, '\\~')
-    .replace(/\`/g, '\\`')
-    .replace(/\>/g, '\\>')
-    .replace(/\#/g, '\\#')
-    .replace(/\+/g, '\\+')
-    .replace(/\-/g, '\\-')
-    .replace(/\=/g, '\\=')
-    .replace(/\|/g, '\\|')
-    .replace(/\{/g, '\\{')
-    .replace(/\}/g, '\\}')
-    .replace(/\./g, '\\.')
-    .replace(/\!/g, '\\!');
-}
 
 function findPlayerByIdentifier(identifier) {
   if (!identifier) return null;


### PR DESCRIPTION
## Summary
- move the escMd markdown escape helper to module scope so player formatting utilities can call it
- remove the redundant in-function definition of escMd inside startBot

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de38c321308333804c287a6de1a7d1