### PR TITLE
Add CRIMECOINS currency and case previews

### DIFF
--- a/lib/items.js
+++ b/lib/items.js
@@ -2,6 +2,22 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+export const CASE_TYPES = Object.freeze({
+  FREE_GIFT: 'free_gift',
+  INVITE: 'invite',
+  INFECTION: 'infection',
+  BASIC: 'basic',
+  LEGEND: 'legend',
+  SIGN: 'sign'
+});
+
+export const GENERAL_CASE_TYPES = [
+  CASE_TYPES.FREE_GIFT,
+  CASE_TYPES.INVITE,
+  CASE_TYPES.INFECTION,
+  CASE_TYPES.BASIC
+];
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT_DIR = path.resolve(__dirname, '..');
@@ -82,6 +98,13 @@ function assignRarity(items, kind) {
   return enriched;
 }
 
+function ensureCaseProps(item, { defaultCases = GENERAL_CASE_TYPES } = {}) {
+  const caseEligible = item.caseEligible !== undefined ? Boolean(item.caseEligible) : true;
+  const rawTypes = Array.isArray(item.caseTypes) ? item.caseTypes : defaultCases;
+  const caseTypes = Array.from(new Set(rawTypes)).filter(Boolean);
+  return { ...item, caseEligible, caseTypes };
+}
+
 const armorItemsBase = [
   { name: "Бронежилет химзащита", hp: 20, chance: 25 },
   { name: "Броня бинты", hp: 30, chance: 22 },
@@ -89,14 +112,14 @@ const armorItemsBase = [
   { name: "Бронежилет любительский", hp: 50, chance: 18 },
   { name: "Бронежилет базовый", hp: 100, chance: 15 },
   { name: "Бронежилет полиции", hp: 250, chance: 10 },
-  { name: "Бронежилет военных", hp: 350, chance: 6 },
-  { name: "Бронежилет CRIMECORE", hp: 500, chance: 4 },
-  { name: "Бронежилет мутации", hp: 550, chance: 2 },
-  { name: "Бронежилет хим. вещества", hp: 600, chance: 1.5 },
-  { name: "Бронежилет протез", hp: 800, chance: 1 },
-  { name: "Броня хай-тек", hp: 1100, chance: 0.5 },
-  { name: "Броня скелет", hp: 1400, chance: 0.3 }
-];
+  { name: "Бронежилет военных", hp: 350, chance: 6, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Бронежилет CRIMECORE", hp: 500, chance: 4, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Бронежилет мутации", hp: 550, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Бронежилет хим. вещества", hp: 600, chance: 1.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Бронежилет протез", hp: 800, chance: 1, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Броня хай-тек", hp: 1100, chance: 0.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Броня скелет", hp: 1400, chance: 0.3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] }
+].map((item) => ensureCaseProps(item));
 
 const weaponItemsBase = [
   { name: "Бита", dmg: 10, chance: 15 },
@@ -106,25 +129,25 @@ const weaponItemsBase = [
   { name: "Топор", dmg: 30, chance: 10 },
   { name: "Мачете", dmg: 30, chance: 10 },
   { name: "Бензопила", dmg: 40, chance: 6 },
-  { name: "Катана", dmg: 45, chance: 5 },
+  { name: "Катана", dmg: 45, chance: 5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
   { name: "Glock-17", dmg: 70, chance: 5 },
   { name: "Tec-9", dmg: 75, chance: 4 },
-  { name: "MP-7", dmg: 100, chance: 3 },
-  { name: "Uzi", dmg: 100, chance: 3 },
-  { name: "UMP", dmg: 120, chance: 2.5 },
-  { name: "Охотничье ружьё", dmg: 170, chance: 2 },
-  { name: "Дробовик", dmg: 180, chance: 1.5 },
-  { name: "Двустволка", dmg: 190, chance: 1.2 },
-  { name: "Famas", dmg: 210, chance: 1 },
-  { name: "M4", dmg: 240, chance: 0.7 },
-  { name: "Ak-47", dmg: 250, chance: 0.8 },
-  { name: "SCAR-L", dmg: 260, chance: 0.7 },
-  { name: "ВСК-94", dmg: 300, chance: 0.5 },
-  { name: "VSS", dmg: 370, chance: 0.25 },
-  { name: "AWP", dmg: 350, chance: 0.3 },
-  { name: "Гранатомет", dmg: 380, chance: 0.2 },
-  { name: "Подопытный", dmg: 450, chance: 0.1 }
-];
+  { name: "MP-7", dmg: 100, chance: 3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Uzi", dmg: 100, chance: 3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "UMP", dmg: 120, chance: 2.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Охотничье ружьё", dmg: 170, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Дробовик", dmg: 180, chance: 1.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Двустволка", dmg: 190, chance: 1.2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Famas", dmg: 210, chance: 1, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "M4", dmg: 240, chance: 0.7, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Ak-47", dmg: 250, chance: 0.8, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "SCAR-L", dmg: 260, chance: 0.7, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "ВСК-94", dmg: 300, chance: 0.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "VSS", dmg: 370, chance: 0.25, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "AWP", dmg: 350, chance: 0.3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Гранатомет", dmg: 380, chance: 0.2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Подопытный", dmg: 450, chance: 0.1, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] }
+].map((item) => ensureCaseProps(item));
 
 const helmetItemsBase = [
   { name: "Пакет", block: 2, chance: 20 },
@@ -137,13 +160,13 @@ const helmetItemsBase = [
   { name: "Велосипедный шлем", block: 5, chance: 15 },
   { name: "Строительный шлем", block: 10, chance: 10 },
   { name: "Противогаз", block: 20, chance: 6 },
-  { name: "Шлем пила", block: 20, chance: 4 },
+  { name: "Шлем пила", block: 20, chance: 4, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
   { name: "Боевой шлем", block: 20, chance: 5 },
-  { name: "Военный шлем", block: 30, chance: 3 },
-  { name: "Шлем ночного видения", block: 25, chance: 2 },
-  { name: "Шлем стальной", block: 35, chance: 1.5 },
-  { name: "Шлем CRIMECORE", block: 40, chance: 2 }
-];
+  { name: "Военный шлем", block: 30, chance: 3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Шлем ночного видения", block: 25, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Шлем стальной", block: 35, chance: 1.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Шлем CRIMECORE", block: 40, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] }
+].map((item) => ensureCaseProps(item));
 
 const mutationItemsBase = [
   { name: "Зубной", crit: 0.10, chance: 25 },
@@ -153,10 +176,10 @@ const mutationItemsBase = [
   { name: "Аниме", crit: 0.20, chance: 15 },
   { name: "Момо", crit: 0.20, chance: 15 },
   { name: "Безликий", crit: 0.25, chance: 12 },
-  { name: "Зубастик", crit: 0.30, chance: 10 },
-  { name: "Клешни", crit: 0.30, chance: 6 },
-  { name: "Бог", crit: 0.50, chance: 2 }
-];
+  { name: "Зубастик", crit: 0.30, chance: 10, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Клешни", crit: 0.30, chance: 6, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+  { name: "Бог", crit: 0.50, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] }
+].map((item) => ensureCaseProps(item));
 
 const extraItemsBase = [
   { name: "Фотоаппарат со вспышкой", effect: "stun2", chance: 20, turns: 2 },
@@ -165,7 +188,7 @@ const extraItemsBase = [
   { name: "Граната", effect: "damage100", chance: 15 },
   { name: "Адреналин", effect: "halfDamage1", chance: 12, turns: 1 },
   { name: "Газовый балон", effect: "doubleDamage1", chance: 6, turns: 1 }
-];
+].map((item) => ensureCaseProps(item));
 
 export const armorItems = assignRarity(armorItemsBase, 'armor');
 export const weaponItems = assignRarity(weaponItemsBase, 'weapon');
@@ -174,14 +197,64 @@ export const mutationItems = assignRarity(mutationItemsBase, 'mutation');
 export const extraItems = assignRarity(extraItemsBase, 'extra');
 
 export const signItems = [
-  { name: "Знак внимание", kind: "sign", vampirism: 0.10, caseEligible: true },
-  { name: "Знак череп", kind: "sign", vampirism: 0.15, caseEligible: true },
-  { name: "Знак 18+", kind: "sign", vampirism: 0.20, caseEligible: true },
-  { name: "Знак CRIMECORE", kind: "sign", vampirism: 0.25, caseEligible: true },
-  { name: "Знак BIOHAZARD", kind: "sign", vampirism: 0.30, caseEligible: true },
-  { name: "Знак радиации", kind: "sign", preventLethal: "radiation", extraTurn: true, caseEligible: true },
-  { name: "Знак пустой", kind: "sign", dodgeChance: 0.20, caseEligible: true },
-  { name: "Знак final CRIMECORE", kind: "sign", preventLethal: "final", fullHeal: true, caseEligible: false }
+  ensureCaseProps({
+    name: "Знак внимание",
+    kind: "sign",
+    vampirism: 0.10,
+    caseEligible: true,
+    caseTypes: [CASE_TYPES.SIGN]
+  }, { defaultCases: [CASE_TYPES.SIGN] }),
+  ensureCaseProps({
+    name: "Знак череп",
+    kind: "sign",
+    vampirism: 0.15,
+    caseEligible: true,
+    caseTypes: [CASE_TYPES.SIGN]
+  }, { defaultCases: [CASE_TYPES.SIGN] }),
+  ensureCaseProps({
+    name: "Знак 18+",
+    kind: "sign",
+    vampirism: 0.20,
+    caseEligible: true,
+    caseTypes: [CASE_TYPES.SIGN]
+  }, { defaultCases: [CASE_TYPES.SIGN] }),
+  ensureCaseProps({
+    name: "Знак CRIMECORE",
+    kind: "sign",
+    vampirism: 0.25,
+    caseEligible: true,
+    caseTypes: [CASE_TYPES.SIGN]
+  }, { defaultCases: [CASE_TYPES.SIGN] }),
+  ensureCaseProps({
+    name: "Знак BIOHAZARD",
+    kind: "sign",
+    vampirism: 0.30,
+    caseEligible: true,
+    caseTypes: [CASE_TYPES.SIGN]
+  }, { defaultCases: [CASE_TYPES.SIGN] }),
+  ensureCaseProps({
+    name: "Знак радиации",
+    kind: "sign",
+    preventLethal: "radiation",
+    extraTurn: true,
+    caseEligible: true,
+    caseTypes: [CASE_TYPES.SIGN]
+  }, { defaultCases: [CASE_TYPES.SIGN] }),
+  ensureCaseProps({
+    name: "Знак пустой",
+    kind: "sign",
+    dodgeChance: 0.20,
+    caseEligible: true,
+    caseTypes: [CASE_TYPES.SIGN]
+  }, { defaultCases: [CASE_TYPES.SIGN] }),
+  ensureCaseProps({
+    name: "Знак final CRIMECORE",
+    kind: "sign",
+    preventLethal: "final",
+    fullHeal: true,
+    caseEligible: false,
+    caseTypes: []
+  }, { defaultCases: [] })
 ];
 
 const ITEM_DEFINITIONS = {
@@ -192,6 +265,34 @@ const ITEM_DEFINITIONS = {
   extra: extraItems,
   sign: signItems
 };
+
+export function getCaseItems(caseType, { includeSigns = false } = {}) {
+  if (!caseType) return [];
+  const pools = [
+    { items: weaponItems, kind: 'weapon' },
+    { items: helmetItems, kind: 'helmet' },
+    { items: mutationItems, kind: 'mutation' },
+    { items: extraItems, kind: 'extra' },
+    { items: armorItems, kind: 'armor' }
+  ];
+
+  if (includeSigns || caseType === CASE_TYPES.SIGN) {
+    pools.push({ items: signItems, kind: 'sign' });
+  }
+
+  const normalized = String(caseType);
+  const eligible = [];
+  for (const { items, kind } of pools) {
+    for (const item of items) {
+      if (!item || item.caseEligible === false) continue;
+      const caseTypes = Array.isArray(item.caseTypes) ? item.caseTypes : GENERAL_CASE_TYPES;
+      if (!caseTypes.includes(normalized)) continue;
+      eligible.push({ ...item, kind });
+    }
+  }
+
+  return eligible;
+}
 
 export const getItemNamesByCategory = () => (
   Object.fromEntries(

--- a/test/buttons.test.js
+++ b/test/buttons.test.js
@@ -20,9 +20,17 @@ test('loot menu contains expected reward options', () => {
   const callbacks = keyboard.inline_keyboard.flat().map(btn => btn.callback_data);
   assert.deepStrictEqual(callbacks, [
     'free_gift',
+    'preview_case:free_gift',
     'invite_friend',
+    'preview_case:invite',
     'sign_case',
+    'preview_case:sign',
     'infection_case',
+    'preview_case:infection',
+    'basic_box',
+    'preview_case:basic',
+    'legend_box',
+    'preview_case:legend',
     'play'
   ]);
 });


### PR DESCRIPTION
## Summary
- add explicit case availability metadata to every item and expose helper utilities for case drops and previews
- extend the loot menu with preview actions, adjust drop logic for all case sources, and surface CRIMECOINS balances plus admin controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de469fca9883339e451e9ceff69319