### PR TITLE
Manually assign rarities for all items

### DIFF
--- a/lib/items.js
+++ b/lib/items.js
@@ -55,8 +55,15 @@ export const getItemImageMap = () => ({ ...ITEM_IMAGE_MAP });
 export const ITEM_RARITY = {
   VERY_RARE: { key: 'very_rare', label: 'крайне редкое' },
   RARE: { key: 'rare', label: 'редкое' },
-  COMMON: { key: 'common', label: 'обычная редкость' }
+  COMMON: { key: 'common', label: 'обычная редкость' },
+  LEGENDARY: { key: 'legendary', label: 'легендарная редкость' }
 };
+
+const applyRarity = (item, rarity) => ({
+  ...item,
+  rarity: rarity.label,
+  rarityKey: rarity.key
+});
 
 function resolveExplicitRarity(item) {
   if (!item) return null;
@@ -166,88 +173,193 @@ function ensureCaseProps(item, { defaultCases = GENERAL_CASE_TYPES } = {}) {
 }
 
 const armorItemsBase = [
-  { name: "Бронежилет химзащита", hp: 20, chance: 25 },
-  { name: "Броня бинты", hp: 30, chance: 22 },
-  { name: "Бронежилет из жертв", hp: 40, chance: 20 },
-  { name: "Бронежилет любительский", hp: 50, chance: 18 },
-  { name: "Бронежилет базовый", hp: 100, chance: 15 },
-  { name: "Бронежилет полиции", hp: 250, chance: 10 },
-  { name: "Бронежилет военных", hp: 350, chance: 6, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Бронежилет CRIMECORE", hp: 500, chance: 4, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Бронежилет мутации", hp: 550, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Бронежилет хим. вещества", hp: 600, chance: 1.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Бронежилет протез", hp: 800, chance: 1, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Броня хай-тек", hp: 1100, chance: 0.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Броня скелет", hp: 1400, chance: 0.3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] }
+  applyRarity({ name: "Бронежилет химзащита", hp: 20, chance: 25 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Броня бинты", hp: 30, chance: 22 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Бронежилет из жертв", hp: 40, chance: 20 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Бронежилет любительский", hp: 50, chance: 18 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Бронежилет базовый", hp: 100, chance: 15 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Бронежилет полиции", hp: 250, chance: 10 }, ITEM_RARITY.RARE),
+  applyRarity(
+    { name: "Бронежилет военных", hp: 350, chance: 6, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.RARE
+  ),
+  applyRarity(
+    { name: "Бронежилет CRIMECORE", hp: 500, chance: 4, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.RARE
+  ),
+  applyRarity(
+    { name: "Бронежилет мутации", hp: 550, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Бронежилет хим. вещества", hp: 600, chance: 1.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Бронежилет протез", hp: 800, chance: 1, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Броня хай-тек", hp: 1100, chance: 0.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Броня скелет", hp: 1400, chance: 0.3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.LEGENDARY
+  )
 ].map((item) => ensureCaseProps(item));
 
 const weaponItemsBase = [
-  { name: "Бита", dmg: 10, chance: 15 },
-  { name: "Перочинный нож", dmg: 15, chance: 13 },
-  { name: "Кухонный нож", dmg: 15, chance: 13 },
-  { name: "Охотничий нож", dmg: 20, chance: 12 },
-  { name: "Топор", dmg: 30, chance: 10 },
-  { name: "Мачете", dmg: 30, chance: 10 },
-  { name: "Бензопила", dmg: 40, chance: 6 },
-  { name: "Катана", dmg: 45, chance: 5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Glock-17", dmg: 70, chance: 5 },
-  { name: "Tec-9", dmg: 75, chance: 4 },
-  { name: "MP-7", dmg: 100, chance: 3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Uzi", dmg: 100, chance: 3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "UMP", dmg: 120, chance: 2.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Охотничье ружьё", dmg: 170, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Дробовик", dmg: 180, chance: 1.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Двустволка", dmg: 190, chance: 1.2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Famas", dmg: 210, chance: 1, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "M4", dmg: 240, chance: 0.7, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Ak-47", dmg: 250, chance: 0.8, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "SCAR-L", dmg: 260, chance: 0.7, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "ВСК-94", dmg: 300, chance: 0.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "VSS", dmg: 370, chance: 0.25, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "AWP", dmg: 350, chance: 0.3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Гранатомет", dmg: 380, chance: 0.2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Подопытный", dmg: 450, chance: 0.1, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] }
+  applyRarity({ name: "Бита", dmg: 10, chance: 15 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Перочинный нож", dmg: 15, chance: 13 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Кухонный нож", dmg: 15, chance: 13 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Охотничий нож", dmg: 20, chance: 12 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Топор", dmg: 30, chance: 10 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Мачете", dmg: 30, chance: 10 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Бензопила", dmg: 40, chance: 6 }, ITEM_RARITY.COMMON),
+  applyRarity(
+    { name: "Катана", dmg: 45, chance: 5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.RARE
+  ),
+  applyRarity({ name: "Glock-17", dmg: 70, chance: 5 }, ITEM_RARITY.RARE),
+  applyRarity({ name: "Tec-9", dmg: 75, chance: 4 }, ITEM_RARITY.RARE),
+  applyRarity(
+    { name: "MP-7", dmg: 100, chance: 3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.RARE
+  ),
+  applyRarity(
+    { name: "Uzi", dmg: 100, chance: 3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.RARE
+  ),
+  applyRarity(
+    { name: "UMP", dmg: 120, chance: 2.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.RARE
+  ),
+  applyRarity(
+    { name: "Охотничье ружьё", dmg: 170, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.RARE
+  ),
+  applyRarity(
+    { name: "Дробовик", dmg: 180, chance: 1.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Двустволка", dmg: 190, chance: 1.2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Famas", dmg: 210, chance: 1, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "M4", dmg: 240, chance: 0.7, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Ak-47", dmg: 250, chance: 0.8, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "SCAR-L", dmg: 260, chance: 0.7, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "ВСК-94", dmg: 300, chance: 0.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "VSS", dmg: 370, chance: 0.25, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "AWP", dmg: 350, chance: 0.3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Гранатомет", dmg: 380, chance: 0.2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Подопытный", dmg: 450, chance: 0.1, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.LEGENDARY
+  )
 ].map((item) => ensureCaseProps(item));
 
 const helmetItemsBase = [
-  { name: "Пакет", block: 2, chance: 20 },
-  { name: "Шлем шапка", block: 3, chance: 19 },
-  { name: "Шлем бинты", block: 3, chance: 19 },
-  { name: "Кепка", block: 3, chance: 18 },
-  { name: "Балаклава", block: 3, chance: 18 },
-  { name: "Кожаный шлем", block: 5, chance: 15 },
-  { name: "Шлем Респиратор", block: 5, chance: 14 },
-  { name: "Велосипедный шлем", block: 5, chance: 15 },
-  { name: "Строительный шлем", block: 10, chance: 10 },
-  { name: "Противогаз", block: 20, chance: 6 },
-  { name: "Шлем пила", block: 20, chance: 4, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Боевой шлем", block: 20, chance: 5 },
-  { name: "Военный шлем", block: 30, chance: 3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Шлем ночного видения", block: 25, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Шлем стальной", block: 35, chance: 1.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Шлем CRIMECORE", block: 40, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] }
+  applyRarity({ name: "Пакет", block: 2, chance: 20 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Шлем шапка", block: 3, chance: 19 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Шлем бинты", block: 3, chance: 19 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Кепка", block: 3, chance: 18 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Балаклава", block: 3, chance: 18 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Кожаный шлем", block: 5, chance: 15 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Шлем Респиратор", block: 5, chance: 14 }, ITEM_RARITY.RARE),
+  applyRarity({ name: "Велосипедный шлем", block: 5, chance: 15 }, ITEM_RARITY.RARE),
+  applyRarity({ name: "Строительный шлем", block: 10, chance: 10 }, ITEM_RARITY.RARE),
+  applyRarity({ name: "Противогаз", block: 20, chance: 6 }, ITEM_RARITY.RARE),
+  applyRarity(
+    { name: "Шлем пила", block: 20, chance: 4, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.RARE
+  ),
+  applyRarity({ name: "Боевой шлем", block: 20, chance: 5 }, ITEM_RARITY.VERY_RARE),
+  applyRarity(
+    { name: "Военный шлем", block: 30, chance: 3, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Шлем ночного видения", block: 25, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Шлем стальной", block: 35, chance: 1.5, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Шлем CRIMECORE", block: 40, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.LEGENDARY
+  )
 ].map((item) => ensureCaseProps(item));
 
 const mutationItemsBase = [
-  { name: "Зубной", crit: 0.10, chance: 25 },
-  { name: "Кровоточащий", crit: 0.15, chance: 20 },
-  { name: "Порезанный", crit: 0.15, chance: 20 },
-  { name: "Молчаливый", crit: 0.20, chance: 18 },
-  { name: "Аниме", crit: 0.20, chance: 15 },
-  { name: "Момо", crit: 0.20, chance: 15 },
-  { name: "Безликий", crit: 0.25, chance: 12 },
-  { name: "Зубастик", crit: 0.30, chance: 10, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Клешни", crit: 0.30, chance: 6, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
-  { name: "Бог", crit: 0.50, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] }
+  applyRarity({ name: "Зубной", crit: 0.10, chance: 25 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Кровоточащий", crit: 0.15, chance: 20 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Порезанный", crit: 0.15, chance: 20 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Молчаливый", crit: 0.20, chance: 18 }, ITEM_RARITY.COMMON),
+  applyRarity({ name: "Аниме", crit: 0.20, chance: 15 }, ITEM_RARITY.RARE),
+  applyRarity({ name: "Момо", crit: 0.20, chance: 15 }, ITEM_RARITY.RARE),
+  applyRarity({ name: "Безликий", crit: 0.25, chance: 12 }, ITEM_RARITY.RARE),
+  applyRarity(
+    { name: "Зубастик", crit: 0.30, chance: 10, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Клешни", crit: 0.30, chance: 6, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Бог", crit: 0.50, chance: 2, caseTypes: [...GENERAL_CASE_TYPES, CASE_TYPES.LEGEND] },
+    ITEM_RARITY.LEGENDARY
+  )
 ].map((item) => ensureCaseProps(item));
 
 const extraItemsBase = [
-  { name: "Фотоаппарат со вспышкой", effect: "stun2", chance: 20, turns: 2 },
-  { name: "Слеповая граната", effect: "stun2", chance: 20, turns: 2 },
-  { name: "Петарда", effect: "damage50", chance: 20 },
-  { name: "Граната", effect: "damage100", chance: 15 },
-  { name: "Адреналин", effect: "halfDamage1", chance: 12, turns: 1 },
-  { name: "Газовый балон", effect: "doubleDamage1", chance: 6, turns: 1 }
+  applyRarity(
+    { name: "Фотоаппарат со вспышкой", effect: "stun2", chance: 20, turns: 2 },
+    ITEM_RARITY.COMMON
+  ),
+  applyRarity(
+    { name: "Слеповая граната", effect: "stun2", chance: 20, turns: 2 },
+    ITEM_RARITY.COMMON
+  ),
+  applyRarity({ name: "Петарда", effect: "damage50", chance: 20 }, ITEM_RARITY.RARE),
+  applyRarity({ name: "Граната", effect: "damage100", chance: 15 }, ITEM_RARITY.RARE),
+  applyRarity(
+    { name: "Адреналин", effect: "halfDamage1", chance: 12, turns: 1 },
+    ITEM_RARITY.VERY_RARE
+  ),
+  applyRarity(
+    { name: "Газовый балон", effect: "doubleDamage1", chance: 6, turns: 1 },
+    ITEM_RARITY.LEGENDARY
+  )
 ].map((item) => ensureCaseProps(item));
 
 export const armorItems = assignRarity(armorItemsBase, 'armor');
@@ -257,64 +369,112 @@ export const mutationItems = assignRarity(mutationItemsBase, 'mutation');
 export const extraItems = assignRarity(extraItemsBase, 'extra');
 
 export const signItems = [
-  ensureCaseProps({
-    name: "Знак внимание",
-    kind: "sign",
-    vampirism: 0.10,
-    caseEligible: true,
-    caseTypes: [CASE_TYPES.SIGN]
-  }, { defaultCases: [CASE_TYPES.SIGN] }),
-  ensureCaseProps({
-    name: "Знак череп",
-    kind: "sign",
-    vampirism: 0.15,
-    caseEligible: true,
-    caseTypes: [CASE_TYPES.SIGN]
-  }, { defaultCases: [CASE_TYPES.SIGN] }),
-  ensureCaseProps({
-    name: "Знак 18+",
-    kind: "sign",
-    vampirism: 0.20,
-    caseEligible: true,
-    caseTypes: [CASE_TYPES.SIGN]
-  }, { defaultCases: [CASE_TYPES.SIGN] }),
-  ensureCaseProps({
-    name: "Знак CRIMECORE",
-    kind: "sign",
-    vampirism: 0.25,
-    caseEligible: true,
-    caseTypes: [CASE_TYPES.SIGN]
-  }, { defaultCases: [CASE_TYPES.SIGN] }),
-  ensureCaseProps({
-    name: "Знак BIOHAZARD",
-    kind: "sign",
-    vampirism: 0.30,
-    caseEligible: true,
-    caseTypes: [CASE_TYPES.SIGN]
-  }, { defaultCases: [CASE_TYPES.SIGN] }),
-  ensureCaseProps({
-    name: "Знак радиации",
-    kind: "sign",
-    preventLethal: "radiation",
-    extraTurn: true,
-    caseEligible: true,
-    caseTypes: [CASE_TYPES.SIGN]
-  }, { defaultCases: [CASE_TYPES.SIGN] }),
-  ensureCaseProps({
-    name: "Знак пустой",
-    kind: "sign",
-    dodgeChance: 0.20,
-    caseEligible: true,
-    caseTypes: [CASE_TYPES.SIGN]
-  }, { defaultCases: [CASE_TYPES.SIGN] }),
-  ensureCaseProps({
-    name: "Знак final CRIMECORE",
-    kind: "sign",
-    preventLethal: "final",
-    fullHeal: true,
-    caseEligible: false,
-    caseTypes: []
-  }, { defaultCases: [] })
+  ensureCaseProps(
+    applyRarity(
+      {
+        name: "Знак внимание",
+        kind: "sign",
+        vampirism: 0.10,
+        caseEligible: true,
+        caseTypes: [CASE_TYPES.SIGN]
+      },
+      ITEM_RARITY.COMMON
+    ),
+    { defaultCases: [CASE_TYPES.SIGN] }
+  ),
+  ensureCaseProps(
+    applyRarity(
+      {
+        name: "Знак череп",
+        kind: "sign",
+        vampirism: 0.15,
+        caseEligible: true,
+        caseTypes: [CASE_TYPES.SIGN]
+      },
+      ITEM_RARITY.COMMON
+    ),
+    { defaultCases: [CASE_TYPES.SIGN] }
+  ),
+  ensureCaseProps(
+    applyRarity(
+      {
+        name: "Знак 18+",
+        kind: "sign",
+        vampirism: 0.20,
+        caseEligible: true,
+        caseTypes: [CASE_TYPES.SIGN]
+      },
+      ITEM_RARITY.COMMON
+    ),
+    { defaultCases: [CASE_TYPES.SIGN] }
+  ),
+  ensureCaseProps(
+    applyRarity(
+      {
+        name: "Знак CRIMECORE",
+        kind: "sign",
+        vampirism: 0.25,
+        caseEligible: true,
+        caseTypes: [CASE_TYPES.SIGN]
+      },
+      ITEM_RARITY.RARE
+    ),
+    { defaultCases: [CASE_TYPES.SIGN] }
+  ),
+  ensureCaseProps(
+    applyRarity(
+      {
+        name: "Знак BIOHAZARD",
+        kind: "sign",
+        vampirism: 0.30,
+        caseEligible: true,
+        caseTypes: [CASE_TYPES.SIGN]
+      },
+      ITEM_RARITY.RARE
+    ),
+    { defaultCases: [CASE_TYPES.SIGN] }
+  ),
+  ensureCaseProps(
+    applyRarity(
+      {
+        name: "Знак радиации",
+        kind: "sign",
+        preventLethal: "radiation",
+        extraTurn: true,
+        caseEligible: true,
+        caseTypes: [CASE_TYPES.SIGN]
+      },
+      ITEM_RARITY.VERY_RARE
+    ),
+    { defaultCases: [CASE_TYPES.SIGN] }
+  ),
+  ensureCaseProps(
+    applyRarity(
+      {
+        name: "Знак пустой",
+        kind: "sign",
+        dodgeChance: 0.20,
+        caseEligible: true,
+        caseTypes: [CASE_TYPES.SIGN]
+      },
+      ITEM_RARITY.VERY_RARE
+    ),
+    { defaultCases: [CASE_TYPES.SIGN] }
+  ),
+  ensureCaseProps(
+    applyRarity(
+      {
+        name: "Знак final CRIMECORE",
+        kind: "sign",
+        preventLethal: "final",
+        fullHeal: true,
+        caseEligible: false,
+        caseTypes: []
+      },
+      ITEM_RARITY.LEGENDARY
+    ),
+    { defaultCases: [] }
+  )
 ];
 
 const ITEM_DEFINITIONS = {


### PR DESCRIPTION
## Summary
- add a dedicated legendary rarity tier and helper for explicit rarity assignments
- manually set rarities for every armor, weapon, helmet, mutation, extra, and sign item so lists progress from common to legendary

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de513e3f5c83339a5e00b0e7750106