### PR TITLE
Avoid duplicate raid DM notifications

### DIFF
--- a/index.js
+++ b/index.js
@@ -3265,7 +3265,15 @@ function sanitizeRaidDirectOptions(options) {
 async function broadcastToRaidParticipants(state, handler) {
   if (!state || typeof handler !== 'function') return;
   const participantIds = getRaidParticipantChatIds(state);
+  const lobbyChatId = state?.chatId;
+  const lobbyChatKey =
+    lobbyChatId === null || lobbyChatId === undefined ? null : String(lobbyChatId);
   for (const participantId of participantIds) {
+    const participantKey =
+      participantId === null || participantId === undefined ? null : String(participantId);
+    if (lobbyChatKey && participantKey && participantKey === lobbyChatKey) {
+      continue;
+    }
     try {
       await handler(participantId);
     } catch (err) {


### PR DESCRIPTION
## Summary
- prevent broadcasting raid updates back into the lobby chat to avoid duplicate direct messages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff67cda948333856d9283630122b0