### PR TITLE
Clarify raid mission invite instructions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3346,7 +3346,8 @@ async function sendRaidPhoto(state, photo, options = undefined) {
 
 async function notifyClanMembersRaidStart(clan) {
   if (!clan || !Array.isArray(clan.members) || clan.members.length === 0) return;
-  const text = 'Ваш клан начал рейд миссию! Отправьте /acceptmission если хотите вступить в лобби!';
+  const text =
+    'Ваш клан начал рейд миссию! Приглашение отправлено всем соклановцам в личные сообщения — вступить в лобби можно из любого чата командой /acceptmission.';
   const notified = new Set();
   for (const memberId of clan.members) {
     if (memberId === null || memberId === undefined) continue;
@@ -3428,7 +3429,7 @@ async function initiateClanRaidMission(player, chatId, options = {}) {
     introLines.push('');
   }
   introLines.push(
-    'Для вступления других соклановцев в ваше лобби им нужно отправить команду /acceptmission',
+    'Для вступления других соклановцев в ваше лобби им нужно отправить команду /acceptmission из любого чата',
     ' ',
     `Игроков в лобби ${state.members.length}/${RAID_MAX_PLAYERS}`,
     'Старт через 130 секунд...'


### PR DESCRIPTION
## Summary
- clarify clan raid mission notifications to explain that invites go to direct messages and /acceptmission can be used from any chat
- update lobby instructions to mention that clanmates can join from any chat

## Testing
- npm test -- --runTestsByPath test/buttons.test.js *(fails: node: bad option: --runTestsByPath)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eb11061c833385a86d7f2f52947a